### PR TITLE
Update README and makefile to include Boost include files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Ensure that the following dependencies are installed before compiling PetIBM:
 * GNU C++ Compiler(`g++`) version 4.6 or above
 * Git distributed version control system (`git`)
 * PETSc version 3.5.0 or above (use branch `petsc-3.4-compatible` to run with PETSc 3.4)
+* [Boost](http://www.boost.org) version 1.55.0 or above
 
-PetIBM has been tested and run on Ubuntu 12.04 and Mac OS X 10.9.
+PetIBM has been tested and run on Ubuntu 12.04, Ubuntu 14.10 and Mac OS X 10.9.
 
 #### GNU C++ Compiler (`g++`)
 
@@ -80,6 +81,10 @@ following lines in your `~/.bashrc` or `~/.bash_profile` files:
 
     > export PETSC_DIR=$HOME/src/petsc-3.5.2
     > export PETSC_ARCH=arch-linux2-c-opt
+
+Set the environment variable `BOOST_INCLUDE` in your `~/.bashrc` or `~/.bash_profile` files:
+
+    > export BOOST_INCLUDE=/path/to/boost/include
 
 **Replace the values above with the version and mode specific to your installation**. Use the `setenv` command to do 
 the same in C shell. Restart the terminal or source the file:

--- a/external/gtest-1.7.0/makefile
+++ b/external/gtest-1.7.0/makefile
@@ -9,7 +9,6 @@ SUFFIX = .cc
 SRC_DIR = src
 SRCS = $(wildcard $(SRC_DIR)/*$(SUFFIX))
 OBJ = $(SRC_DIR)/gtest-all.o
-LIB_DIR = $(PETIBM_DIR)/lib
 CLEANFILES = $(OBJ)
 
 ALL: $(TARGET)
@@ -17,7 +16,7 @@ ALL: $(TARGET)
 include $(PETSC_DIR)/conf/variables
 include $(PETSC_DIR)/conf/rules
 
-PETSC_CC_INCLUDES += -I./include -I./
+PETSC_CC_INCLUDES += -I ./include -I ./
 
 $(TARGET): $(OBJ)
 	$(AR) $(ARFLAGS) $@ $^

--- a/external/yaml-cpp-0.5.1/makefile
+++ b/external/yaml-cpp-0.5.1/makefile
@@ -8,7 +8,6 @@ TARGET = libyaml.a
 SUFFIX = .cpp
 SRCS = $(wildcard src/*$(SUFFIX)) $(wildcard src/contrib/*$(SUFFIX))
 OBJ = $(SRCS:$(SUFFIX)=.o)
-LIB_DIR = $(PETIBM_DIR)/lib
 CLEANFILES = $(OBJ)
 
 ALL: $(TARGET)
@@ -16,7 +15,7 @@ ALL: $(TARGET)
 include $(PETSC_DIR)/conf/variables
 include $(PETSC_DIR)/conf/rules
 
-PETSC_CC_INCLUDES += -I./include
+PETSC_CC_INCLUDES += -I ./include -I $(BOOST_INCLUDE)
 
 $(TARGET): $(OBJ)
 	$(AR) $(ARFLAGS) $@ $^

--- a/makefile
+++ b/makefile
@@ -12,13 +12,15 @@ BIN_DIR = $(PETIBM_DIR)/bin
 PETIBM2D = $(BIN_DIR)/PetIBM2d
 PETIBM3D = $(BIN_DIR)/PetIBM3d
 
-LIB_DIR = $(PETIBM_DIR)/lib
+export LIB_DIR = $(PETIBM_DIR)/lib
 LIBS = $(addprefix $(LIB_DIR)/, libclasses.a libsolvers.a)
 EXT_LIBS = $(addprefix $(LIB_DIR)/, libyaml.a libgtest.a)
 
 EXT_DIR = $(PETIBM_DIR)/external
-YAML_OBJS = $(shell find $(EXT_DIR)/yaml-cpp-0.5.1 -type f -name *.o)
-GTEST_OBJS = $(shell find $(EXT_DIR)/gtest-1.7.0 -type f -name *.o)
+export YAML = $(EXT_DIR)/yaml-cpp-0.5.1
+YAML_OBJS = $(shell find $(YAML) -type f -name *.o)
+GTEST = $(EXT_DIR)/gtest-1.7.0
+GTEST_OBJS = $(shell find $(GTEST) -type f -name *.o)
 
 .PHONY: ALL
 
@@ -28,19 +30,11 @@ include $(PETSC_DIR)/conf/variables
 include $(PETSC_DIR)/conf/rules
 
 # locations of include files
-PETSC_CC_INCLUDES += -I./src/include \
-										 -I./src/solvers \
-										 -I./external/gtest-1.7.0/include
+PETSC_CC_INCLUDES += -I ./src/include -I ./src/solvers -I $(GTEST)/include
 
 PCC_FLAGS += -std=c++0x -Wextra -pedantic
 CXX_FLAGS += -std=c++0x -Wextra -pedantic
-PCC_LINKER_FLAGS += -I./external/gtest-1.7.0/include
-
-$(SRC_DIR)/PetIBM2d.o: $(SRC_DIR)/PetIBM.cpp
-	$(PETSC_COMPILE) -D DIMENSIONS=2 $^ -o $@
-
-$(SRC_DIR)/PetIBM3d.o: $(SRC_DIR)/PetIBM.cpp
-	$(PETSC_COMPILE) -D DIMENSIONS=3 $^ -o $@
+PCC_LINKER_FLAGS += -I $(GTEST)/include
 
 $(PETIBM2D): $(SRC_DIR)/PetIBM2d.o $(LIBS) $(EXT_LIBS)
 	@echo "\n$@ - Linking ..."
@@ -52,6 +46,12 @@ $(PETIBM3D): $(SRC_DIR)/PetIBM3d.o $(LIBS) $(EXT_LIBS)
 	@mkdir -p $(BIN_DIR)
 	$(CLINKER) $^ -o $@ $(PETSC_SYS_LIB)
 
+$(SRC_DIR)/PetIBM2d.o: $(SRC_DIR)/PetIBM.cpp
+	$(PETSC_COMPILE) -D DIMENSIONS=2 $^ -o $@
+
+$(SRC_DIR)/PetIBM3d.o: $(SRC_DIR)/PetIBM.cpp
+	$(PETSC_COMPILE) -D DIMENSIONS=3 $^ -o $@
+
 $(LIBS):
 	@echo "\nGenerating static libraries ..."
 	@mkdir -p $(LIB_DIR)
@@ -61,8 +61,8 @@ $(LIBS):
 $(EXT_LIBS):
 	@echo "\nGenerating external static libraries ..."
 	@mkdir -p $(LIB_DIR)
-	cd external/yaml-cpp-0.5.1; $(MAKE)
-	cd external/gtest-1.7.0; $(MAKE)
+	cd $(YAML); $(MAKE)
+	cd $(GTEST); $(MAKE)
 
 ################################################################################
 
@@ -75,12 +75,8 @@ TESTS_BIN = $(TESTS_SRCS:$(SUFFIX)=)
 
 tests: $(TESTS_BIN)
 	$(TESTS_DIR)/CartesianMeshTest
-	$(TESTS_DIR)/NavierStokesTest -caseFolder tests/NavierStokes \
-												 				-sys2_pc_type gamg -sys2_pc_gamg_type agg \
-												 				-sys2_pc_gamg_agg_nsmooths 1
-	$(TESTS_DIR)/TairaColoniusTest -caseFolder tests/TairaColonius \
-																 -sys2_pc_type gamg -sys2_pc_gamg_type agg \
-																 -sys2_pc_gamg_agg_nsmooths 1
+	$(TESTS_DIR)/NavierStokesTest -caseFolder tests/NavierStokes -sys2_pc_type gamg -sys2_pc_gamg_type agg -sys2_pc_gamg_agg_nsmooths 1
+	$(TESTS_DIR)/TairaColoniusTest -caseFolder tests/TairaColonius -sys2_pc_type gamg -sys2_pc_gamg_type agg -sys2_pc_gamg_agg_nsmooths 1
 
 $(TESTS_DIR)/CartesianMeshTest: $(TESTS_DIR)/CartesianMeshTest.cpp $(LIBS) $(EXT_LIBS)
 	$(CXX) $(PETSC_CC_INCLUDES) -std=c++0x -pthread $^ -o $@ $(PETSC_SYS_LIB)

--- a/src/include/makefile
+++ b/src/include/makefile
@@ -8,7 +8,6 @@ TARGET = libclasses.a
 SUFFIX = .cpp
 SRCS = $(wildcard *$(SUFFIX))
 OBJ = $(SRCS:$(SUFFIX)=.o)
-LIB_DIR = $(PETIBM_DIR)/lib
 CLEANFILES = $(OBJ)
 
 ALL: $(TARGET)
@@ -16,7 +15,7 @@ ALL: $(TARGET)
 include $(PETSC_DIR)/conf/variables
 include $(PETSC_DIR)/conf/rules
 
-PETSC_CC_INCLUDES += -I../../external/yaml-cpp-0.5.1/include
+PETSC_CC_INCLUDES += -I $(YAML)/include -I $(BOOST_INCLUDE)
 
 $(TARGET): $(OBJ)
 	$(AR) $(ARFLAGS) $@ $^

--- a/src/solvers/makefile
+++ b/src/solvers/makefile
@@ -8,7 +8,6 @@ TARGET = libsolvers.a
 SUFFIX = .cpp
 SRCS = $(wildcard *$(SUFFIX))
 OBJ = $(SRCS:$(SUFFIX)=.o)
-LIB_DIR = $(PETIBM_DIR)/lib
 CLEANFILES = $(OBJ)
 
 ALL: $(TARGET)
@@ -16,7 +15,7 @@ ALL: $(TARGET)
 include $(PETSC_DIR)/conf/variables
 include $(PETSC_DIR)/conf/rules
 
-PETSC_CC_INCLUDES += -I../../external/yaml-cpp-0.5.1/include -I../include
+PETSC_CC_INCLUDES += -I $(YAML)/include -I ../include -I $(BOOST_INCLUDE)
 PCC_FLAGS += -std=c++0x -Wall -Wextra -pedantic -MMD
 CXX_FLAGS += -std=c++0x -Wall -Wextra -pedantic -MMD
 


### PR DESCRIPTION
Because the new version of `yaml-cpp` is using the header files of the library [Boost](http://www.boost.org), I adapted the makefiles and the README.

in addition to set the environment variables `PETIBM_DIR`, `PETSC_DIR` and `PETSC_ARCH`, the user must also set the variable `BOOST_INCLUDE` with the path to the boost folder.
For example on `phantom`, the Boost header files are located in `/usr/include` so that the following line is added to my `~/.bashrc` file:

> export BOOST_INCLUDE=/usr/include

@anushkrish : is this branch compiling correctly on your machine?
`make cleanall`, `make` and `make -j4` work correctly on `phantom`.