### PR TITLE
add Python3 compatibility to ioPetIBM

### DIFF
--- a/scripts/python/ioPetIBM.py
+++ b/scripts/python/ioPetIBM.py
@@ -12,6 +12,11 @@ import numpy
 sys.path.append(os.path.join(os.environ['PETSC_DIR'], 'bin', 'pythonscripts'))
 import PetscBinaryIO
 
+#reduce is no longer a builtin in Python 3
+#but has been added to the functools package
+if sys.version_info[0] >= 3:
+    from functools import reduce
+
 
 class Field(object):
   """Contains information about a field (pressure for example)."""


### PR DESCRIPTION
ioPetIBM.py calls the Python 2 built-in `reduce` which has been removed as a built-in in Python 3.  This just adds a quick version check and if the Python version >= 3, it does a `from functools import reduce`.