### PR TITLE
Use MatSetOption(...) to not save zero entries

### DIFF
--- a/src/solvers/navierStokes/inline/generateBNQ.inl
+++ b/src/solvers/navierStokes/inline/generateBNQ.inl
@@ -81,6 +81,7 @@ PetscErrorCode NavierStokesSolver<2>::generateBNQ()
   ierr = MatSetFromOptions(BNQ); CHKERRQ(ierr);
   ierr = MatSeqAIJSetPreallocation(BNQ, 0, d_nnz); CHKERRQ(ierr);
   ierr = MatMPIAIJSetPreallocation(BNQ, 0, d_nnz, 0, o_nnz); CHKERRQ(ierr);
+  ierr = MatSetOption(BNQ, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE); CHKERRQ(ierr);
 
   // deallocate d_nnz and o_nnz
   ierr = PetscFree(d_nnz); CHKERRQ(ierr);
@@ -215,6 +216,7 @@ PetscErrorCode NavierStokesSolver<3>::generateBNQ()
   ierr = MatSetFromOptions(BNQ); CHKERRQ(ierr);
   ierr = MatSeqAIJSetPreallocation(BNQ, 0, d_nnz); CHKERRQ(ierr);
   ierr = MatMPIAIJSetPreallocation(BNQ, 0, d_nnz, 0, o_nnz); CHKERRQ(ierr);
+  ierr = MatSetOption(BNQ, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE); CHKERRQ(ierr);
 
   // deallocate d_nnz and o_nnz
   ierr = PetscFree(d_nnz); CHKERRQ(ierr);

--- a/src/solvers/tairaColonius/inline/generateBNQ.inl
+++ b/src/solvers/tairaColonius/inline/generateBNQ.inl
@@ -158,12 +158,14 @@ PetscErrorCode TairaColoniusSolver<2>::generateBNQ()
   ierr = MatSetFromOptions(BNQ); CHKERRQ(ierr);
   ierr = MatSeqAIJSetPreallocation(BNQ, 0, BNQ_d_nnz); CHKERRQ(ierr);
   ierr = MatMPIAIJSetPreallocation(BNQ, 0, BNQ_d_nnz, 0, BNQ_o_nnz); CHKERRQ(ierr);
+  ierr = MatSetOption(BNQ, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE); CHKERRQ(ierr);
   // ET
   ierr = MatCreate(PETSC_COMM_WORLD, &ET); CHKERRQ(ierr);
   ierr = MatSetSizes(ET, qLocalSize, fLocalSize, PETSC_DETERMINE, PETSC_DETERMINE); CHKERRQ(ierr);
   ierr = MatSetFromOptions(ET); CHKERRQ(ierr);
   ierr = MatSeqAIJSetPreallocation(ET, 0, ET_d_nnz); CHKERRQ(ierr);
   ierr = MatMPIAIJSetPreallocation(ET, 0, ET_d_nnz, 0, ET_o_nnz); CHKERRQ(ierr);
+  ierr = MatSetOption(ET, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE); CHKERRQ(ierr);
 
   // deallocate nnz arrays
   // BNQ
@@ -466,12 +468,14 @@ PetscErrorCode TairaColoniusSolver<3>::generateBNQ()
   ierr = MatSetFromOptions(BNQ); CHKERRQ(ierr);
   ierr = MatSeqAIJSetPreallocation(BNQ, 0, BNQ_d_nnz); CHKERRQ(ierr);
   ierr = MatMPIAIJSetPreallocation(BNQ, 0, BNQ_d_nnz, 0, BNQ_o_nnz); CHKERRQ(ierr);
+  ierr = MatSetOption(BNQ, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE); CHKERRQ(ierr);
   // ET
   ierr = MatCreate(PETSC_COMM_WORLD, &ET); CHKERRQ(ierr);
   ierr = MatSetSizes(ET, qLocalSize, fLocalSize, PETSC_DETERMINE, PETSC_DETERMINE); CHKERRQ(ierr);
   ierr = MatSetFromOptions(ET); CHKERRQ(ierr);
   ierr = MatSeqAIJSetPreallocation(ET, 0, ET_d_nnz); CHKERRQ(ierr);
   ierr = MatMPIAIJSetPreallocation(ET, 0, ET_d_nnz, 0, ET_o_nnz); CHKERRQ(ierr);
+  ierr = MatSetOption(ET, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE); CHKERRQ(ierr);
 
   // deallocate nnz arrays
   // BNQ


### PR DESCRIPTION
Zero-value entries were observed in BNQ, QT, and QTBNQ in Taira-Colinus solver. Though this may not cause any problem, I decide to clean these zero values from the non-zero structure of the sparse matrices, so that they won't occupy extra non-necessary GPU memory when using AmgX solvers.