### PR TITLE
Output the numerical solution in HDF5 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 * Compatibility with PETSc-3.7 (last tested 3.7.4; cannot use 3.5 and 3.6 anymore).
 * A change log.
+* Possibility to output the numerical solution in HDF5 format.
+* Possibility to output the flux and/or velocity variables.
+* Python script `createXMFFile.py` that generates a `.xmf` file to let VisIt know how to read the HDF5 files.
 
 ### Changed
 

--- a/doc/inputs.md
+++ b/doc/inputs.md
@@ -4,7 +4,6 @@ A simulation directory must contain some input files in order to run the program
 
 * The file [[cartesianMesh.yaml]] is required to generate a structured Cartesian grid (uniform or stretched).
 
-
 * The file [[simulationParameters.yaml]] contains the parameters related to the time-scheme. They include the number of time-steps, the time-increment, the saving time-step interval, the starting time-step, the name of the immersed-boundary method to use (if body present in the domain), as well as the temporal scheme for the convective and diffusive terms of the momentum equation.
 
 The following files are optional:

--- a/doc/outputs.md
+++ b/doc/outputs.md
@@ -6,8 +6,14 @@ All PetIBM output files created during the course of the simulation are located 
 
 * `iterationCounts.txt`: this file consists of three columns - the first columns contains the time-step index; the second and third columns contain the number of iterations at a time-step required by the iterative solvers to converge (second column for the velocity solver, third one for the Poisson solver).
 
-* Every given time-step interval (see `nsave` in the input file `simulationParameters.yaml`), the numerical solution if saved in a sub-folder whose name is the time-step index. Each sub-folder contains the following files:
-  * `qx.dat`, `qy.dat`, and `qz.dat`: PETSc binary files that store the velocity flux components through each cell faces in the domain.
-  * `phi.dat`: PETSc binary file that stores the values of discrete pressure field.
-  * `fTilde.dat`: this file is created only if an immersed boundary is present in the computational domain. It is a PETSc binary file that stores a vector of the rescaled body forces calculated at every boundary point.
-  * Along with the above files, the corresponding `.info` files are also written, which are used by PETSc.
+* The sub-folder `grids` is generated **only** when HDF5 is chosen as output format (by adding the line `outputFormat: hdf5` to your input file `simulationParameters.yaml`). The folder contains files that store the locations in the computational domain of a cell-centered quantity (`cell-centered.h5`) and of the vector components of a staggered quantity (`staggered-x.h5`, `staggered-y.h5`, and `staggered-z.h5` for 3D runs).
+
+* Every given time-step interval (see `nsave` in the input file `simulationParameters.yaml`), the numerical solution if saved in a sub-folder whose name is the time-step index. The content of these folders depends on the type of output requested (we support PETSc binary and HDF5 formats) and the variables you choose to save (velocity and/or flux components; the pressure field is always saved).
+
+For example, if you choose the PETSc binary format and decide to save the flux components, each sub-folder will contain the following files: 
+  - `qx.dat`, `qy.dat`, and `qz.dat` (for 3D runs): files that store the velocity flux components through each cell faces in the domain;
+  - `phi.dat`: file that stores the values of the discrete pressure field;
+  - `fTilde.dat` (if immersed boundary present in the flow): file that stores a vector of the rescaled body forces calculated at every boundary point;
+  - a `.info` file for each quantity saved that is used by PETSc to read the files.
+
+In case where you choose a HDF5 format and decide to save the velocity components, a time-step sub-folder will contain the following files: `phi.h5`, `ux.h5`, `uy.h5`, `uz.h5` (for 3D runs), `fTilde.h5` (if you have an immersed boundary).

--- a/doc/simulationParameters.yaml.md
+++ b/doc/simulationParameters.yaml.md
@@ -16,6 +16,9 @@ The simulation parameters do not depend on the dimensionality of the problem, an
       ibm: TAIRA_COLONIUS
       convection: ADAMS_BASHFORTH_2
       diffusion: CRANK_NICOLSON
+      outputFormat: binary
+      outputFlux: true
+      outputVelocity: true
 
 
 ## File options
@@ -27,3 +30,6 @@ The simulation parameters do not depend on the dimensionality of the problem, an
 * `ibm`: (optional) specifies the immersed boundary method used in the simulation. Currently, the only immersed boundary method available in PetIBM is `TAIRA_COLONIUS`. If no immersed boundary are present in the computational domain, once should remove this line.
 * `convection`: (optional, default: `EULER_EXPLICIT`) specifies the time-scheme to use for the convective terms of the momentum equation. In PetIBM, the convective terms can be temporally discretized using an explicit Euler method (`EULER_EXPLICIT`, default value) or a second-order Adams-Bashforth scheme (`ADAMS_BASHFORTH_2`).
 * `diffusion`: (optional, default: `EULER_IMPLICIT`) specifies the time-scheme to use for the diffusive terms of the momentum equation. In PetIBM, the diffusive terms can be  treated explicitly (`EULER_EXPLICIT`), implicitly (`EULER_IMPLICIT`, default), or using a second-order Crank-Nicolson scheme (`CRANK_NICOLSON`).
+* `outputFormat`: (optional, default: `binary`) specifies the format of the output files in which the numerical solution is stored. Right now, two formats are supported: `binary` and `hdf5`.
+* `outputFlux`: (optional, default: `true`) writes the flux variable into files when set to `true`.
+* `outputVelocity`: (optional, default: `false`) writes the velocity variable into files when set to `true`.

--- a/scripts/python/createXMFFile.py
+++ b/scripts/python/createXMFFile.py
@@ -14,8 +14,7 @@ def parse_command_line():
   print('\nParsing command-line ...'),
   # create parser
   formatter_class = argparse.ArgumentDefaultsHelpFormatter
-  parser = argparse.ArgumentParser(description='Plots the instantaneous '
-                                               'forces',
+  parser = argparse.ArgumentParser(description='Creates a XMF file',
                                    formatter_class=formatter_class)
   # fill parser with arguments
   parser.add_argument('--directory', dest='directory',
@@ -106,7 +105,8 @@ def main():
     topology_type = '3DRectMesh'
     geometry_type = 'VXVYVZ'
     components = ('x', 'y', 'z')
-  number_of_elements = ' '.join(str(n) for n in args.grid_size)
+  number_of_elements = ' '.join(str(n) for n in args.grid_size[::-1])
+  precision = '8'
   # create an xmf block for each time-step saved
   for it, time_value in time_values:
     grid = ET.SubElement(grid_time_series, 'Grid',
@@ -124,7 +124,7 @@ def main():
       dataitem = ET.SubElement(geometry, 'DataItem',
                                Dimensions=str(n),
                                NumberType='Float',
-                               Precision='4',
+                               Precision=precision,
                                Format='HDF')
       dataitem.text = '{}:/{}'.format(os.path.join(args.directory,
                                                    args.grid_file), d)
@@ -137,7 +137,7 @@ def main():
       dataitem = ET.SubElement(attribute, 'DataItem',
                                Dimensions=number_of_elements,
                                NumberType='Float',
-                               Precision='4',
+                               Precision=precision,
                                Format='HDF')
       variable_file_path = os.path.join(args.directory,
                                         '{:0>7}'.format(it),

--- a/scripts/python/createXMFFile.py
+++ b/scripts/python/createXMFFile.py
@@ -1,0 +1,156 @@
+"""
+Creates a single XMF file that includes info for each time-step saved.
+"""
+
+import os
+import argparse
+from lxml import etree as ET
+
+import numpy
+
+
+def parse_command_line():
+  """Parses the command-line."""
+  print('\nParsing command-line ...'),
+  # create parser
+  formatter_class = argparse.ArgumentDefaultsHelpFormatter
+  parser = argparse.ArgumentParser(description='Plots the instantaneous '
+                                               'forces',
+                                   formatter_class=formatter_class)
+  # fill parser with arguments
+  parser.add_argument('--directory', dest='directory',
+                      type=str,
+                      default=os.getcwd(),
+                      metavar='<directory>',
+                      help='directory of the simulation')
+  parser.add_argument('--grid-file', dest='grid_file',
+                      type=str,
+                      metavar='<fileName>',
+                      help='name of the grid file')
+  parser.add_argument('--grid-size', dest='grid_size',
+                      type=int,
+                      nargs='+',
+                      help='grid size')
+  parser.add_argument('--variables', dest='variables',
+                      type=str,
+                      nargs='+',
+                      default=('var1', 'var2'),
+                      metavar=('<var1>', '<var2>'),
+                      help='list of variables to include')
+  parser.add_argument('--times-file', dest='times_file',
+                      type=str,
+                      metavar='<fileName>',
+                      help='name of the file containing the map '
+                           '(index, time-unit)')
+  parser.add_argument('--outfile', dest='outfile',
+                      type=str,
+                      default='example.xmf',
+                      metavar='<fileName>',
+                      help='name of output .xmf file')
+  parser.add_argument('--options',
+                      type=open, action=ReadOptionsFromFile,
+                      metavar='<filePath>',
+                      help='path of the file with options to parse')
+  print('done')
+  # return namespace
+  return parser.parse_args()
+
+
+class ReadOptionsFromFile(argparse.Action):
+  """
+  Container to read parameters from file.
+  """
+
+  def __call__(self, parser, namespace, values, option_string=None):
+    """
+    Fills the namespace with parameters read in file.
+    """
+    with values as infile:
+      lines = [element for line in infile.readlines()
+               for element in line.strip().split()
+               if not line.startswith('#')]
+      lines = [os.path.expandvars(line) if '$' in line else line
+               for line in lines[:]]
+    parser.parse_args(lines, namespace)
+
+
+def main():
+  """
+  Creates an XMF file with support for multiple variables
+  (that share the same grid).
+  """
+  # get the user configuration
+  args = parse_command_line()
+  print('User-configuration:\n{}'.format(args))
+  # read file containing index and corresponding
+  # time at which solution was saved
+  with open(args.times_file, 'r') as infile:
+    time_values = numpy.genfromtxt(infile, dtype=None)
+  # start xmf tree
+  xdmf = ET.Element('Xdmf',
+                    Version='2.2')
+  info = ET.SubElement(xdmf, 'Information',
+                       Name='MetaData',
+                       Value='ID-23454')
+  domain = ET.SubElement(xdmf, 'Domain')
+  grid_time_series = ET.SubElement(domain, 'Grid',
+                                   Name='TimeSeries',
+                                   GridType='Collection',
+                                   CollectionType='Temporal')
+  # define type of field
+  if len(args.grid_size) == 2:
+    topology_type = '2DRectMesh'
+    geometry_type = 'VXVY'
+    components = ('x', 'y')
+  elif len(args.grid_size) == 3:
+    topology_type = '3DRectMesh'
+    geometry_type = 'VXVYVZ'
+    components = ('x', 'y', 'z')
+  number_of_elements = ' '.join(str(n) for n in args.grid_size)
+  # create an xmf block for each time-step saved
+  for it, time_value in time_values:
+    grid = ET.SubElement(grid_time_series, 'Grid',
+                         Name='Grid',
+                         GridType='Uniform')
+    time = ET.SubElement(grid, 'Time',
+                         Value=str(time_value))
+    topology = ET.SubElement(grid, 'Topology',
+                             TopologyType=topology_type,
+                             NumberOfElements=number_of_elements)
+    geometry = ET.SubElement(grid, 'Geometry',
+                             GeometryType=geometry_type)
+    # loop over the 3 directions (for code-reuse purpose)
+    for d, n in zip(components, args.grid_size):
+      dataitem = ET.SubElement(geometry, 'DataItem',
+                               Dimensions=str(n),
+                               NumberType='Float',
+                               Precision='4',
+                               Format='HDF')
+      dataitem.text = '{}:/{}'.format(os.path.join(args.directory,
+                                                   args.grid_file), d)
+    # create a block for each variable to insert
+    for variable in args.variables:
+      attribute = ET.SubElement(grid, 'Attribute',
+                                Name=variable,
+                                AttributeType='Scalar',
+                                Center='Node')
+      dataitem = ET.SubElement(attribute, 'DataItem',
+                               Dimensions=number_of_elements,
+                               NumberType='Float',
+                               Precision='4',
+                               Format='HDF')
+      variable_file_path = os.path.join(args.directory,
+                                        '{:0>7}'.format(it),
+                                        '{}.h5'.format(variable))
+      dataitem.text = '{}:/{}'.format(variable_file_path, variable)
+  # write the xmf file
+  print('\nWriting XMF file: {} ...'.format(args.outfile)),
+  tree = ET.ElementTree(xdmf)
+  tree.write(args.outfile, pretty_print=True, xml_declaration=True)
+  print('done')
+
+
+if __name__ == '__main__':
+  print('\n[{}] START\n'.format(os.path.basename(__file__)))
+  main()
+  print('\n[{}] END\n'.format(os.path.basename(__file__)))

--- a/scripts/python/createXMFFile.py
+++ b/scripts/python/createXMFFile.py
@@ -85,6 +85,8 @@ def main():
   # time at which solution was saved
   with open(args.times_file, 'r') as infile:
     time_values = numpy.genfromtxt(infile, dtype=None)
+  if time_values.size == 1:
+    time_values = numpy.array([time_values])
   # start xmf tree
   xdmf = ET.Element('Xdmf',
                     Version='2.2')

--- a/src/PetIBM.cpp
+++ b/src/PetIBM.cpp
@@ -54,7 +54,6 @@ int main(int argc,char **argv)
                                                                         &parameters);
   
   ierr = solver->initialize(); CHKERRQ(ierr);
-  ierr = solver->writeData(); CHKERRQ(ierr);
   
   while(!solver->finished())
   {

--- a/src/PetIBM.cpp
+++ b/src/PetIBM.cpp
@@ -54,6 +54,7 @@ int main(int argc,char **argv)
                                                                         &parameters);
   
   ierr = solver->initialize(); CHKERRQ(ierr);
+  ierr = solver->writeData(); CHKERRQ(ierr);
   
   while(!solver->finished())
   {

--- a/src/PetIBM.cpp
+++ b/src/PetIBM.cpp
@@ -41,13 +41,17 @@ int main(int argc,char **argv)
   ierr = PetscPrintf(PETSC_COMM_WORLD, "directory: %s\n", directory.c_str()); CHKERRQ(ierr);
 
   // read different input files
-  CartesianMesh cartesianMesh(directory);
-  FlowDescription<dim> flowDescription(directory);
-  SimulationParameters simulationParameters(directory);
+  CartesianMesh mesh(directory);
+  ierr = mesh.printInfo(); CHKERRQ(ierr);
+  ierr = mesh.write(directory+"/grid.txt");
+  FlowDescription<dim> flow(directory);
+  ierr = flow.printInfo(); CHKERRQ(ierr);
+  SimulationParameters parameters(directory);
+  ierr = parameters.printInfo(); CHKERRQ(ierr);
 
-  std::unique_ptr< NavierStokesSolver<dim> > solver = createSolver<dim>(&cartesianMesh,
-                                                                        &flowDescription, 
-                                                                        &simulationParameters);
+  std::unique_ptr< NavierStokesSolver<dim> > solver = createSolver<dim>(&mesh,
+                                                                        &flow,
+                                                                        &parameters);
   
   ierr = solver->initialize(); CHKERRQ(ierr);
   

--- a/src/PetIBM.cpp
+++ b/src/PetIBM.cpp
@@ -54,6 +54,7 @@ int main(int argc,char **argv)
                                                                         &parameters);
   
   ierr = solver->initialize(); CHKERRQ(ierr);
+  ierr = PetscPrintf(PETSC_COMM_WORLD, "\nInitialization complete!\n"); CHKERRQ(ierr);
   
   while(!solver->finished())
   {

--- a/src/solvers/navierStokes/NavierStokesSolver.cpp
+++ b/src/solvers/navierStokes/NavierStokesSolver.cpp
@@ -109,7 +109,10 @@ PetscErrorCode NavierStokesSolver<dim>::initializeCommon()
 {
   PetscErrorCode ierr;
 
-  ierr = writeGrids(); CHKERRQ(ierr);
+  if (parameters->fileFormat == "hdf5")
+  {
+    ierr = writeGrids(); CHKERRQ(ierr);
+  }
 
   ierr = createVecs(); CHKERRQ(ierr);
   

--- a/src/solvers/navierStokes/NavierStokesSolver.cpp
+++ b/src/solvers/navierStokes/NavierStokesSolver.cpp
@@ -111,7 +111,7 @@ PetscErrorCode NavierStokesSolver<dim>::initializeCommon()
 
   PetscFunctionBeginUser;
 
-  if (parameters->fileFormat == "hdf5")
+  if (parameters->outputFormat == "hdf5")
   {
     ierr = writeGrids(); CHKERRQ(ierr);
   }

--- a/src/solvers/navierStokes/NavierStokesSolver.cpp
+++ b/src/solvers/navierStokes/NavierStokesSolver.cpp
@@ -111,10 +111,12 @@ PetscErrorCode NavierStokesSolver<dim>::initializeCommon()
 
   PetscFunctionBeginUser;
 
+#ifdef PETSC_HAVE_HDF5
   if (parameters->outputFormat == "hdf5")
   {
     ierr = writeGrids(); CHKERRQ(ierr);
   }
+#endif
 
   ierr = createVecs(); CHKERRQ(ierr);
 

--- a/src/solvers/navierStokes/NavierStokesSolver.cpp
+++ b/src/solvers/navierStokes/NavierStokesSolver.cpp
@@ -130,16 +130,7 @@ PetscErrorCode NavierStokesSolver<dim>::initializeCommon()
 
   if (parameters->startStep > 0 || flow->initialCustomField)
   {
-    ierr = PetscPrintf(PETSC_COMM_WORLD,
-                       "\n[time-step %d] Reading numerical solution from files... ",
-                       timeStep); CHKERRQ(ierr);
-    std::stringstream ss;
-    ss << parameters->directory << "/" << std::setfill('0') << std::setw(7) << parameters->startStep;
-    std::string solutionDirectory = ss.str();
-    ierr = readFluxes(solutionDirectory); CHKERRQ(ierr);
-    ierr = readLambda(solutionDirectory); CHKERRQ(ierr);
-
-    ierr = PetscPrintf(PETSC_COMM_WORLD, "done\n"); CHKERRQ(ierr);
+    ierr = readData(); CHKERRQ(ierr);
   }
   else
   {

--- a/src/solvers/navierStokes/NavierStokesSolver.cpp
+++ b/src/solvers/navierStokes/NavierStokesSolver.cpp
@@ -92,10 +92,8 @@ PetscErrorCode NavierStokesSolver<dim>::initialize()
 
   ierr = PetscLogStagePush(stageInitialize); CHKERRQ(ierr);
   
-  ierr = printInfo(); CHKERRQ(ierr);
   ierr = createDMs(); CHKERRQ(ierr);
   ierr = initializeCommon(); CHKERRQ(ierr);
-  ierr = writeGrid(); CHKERRQ(ierr);
   
   ierr = PetscLogStagePop(); CHKERRQ(ierr);
 
@@ -110,6 +108,8 @@ template <PetscInt dim>
 PetscErrorCode NavierStokesSolver<dim>::initializeCommon()
 {
   PetscErrorCode ierr;
+
+  ierr = writeGrids(); CHKERRQ(ierr);
 
   ierr = createVecs(); CHKERRQ(ierr);
   

--- a/src/solvers/navierStokes/NavierStokesSolver.h
+++ b/src/solvers/navierStokes/NavierStokesSolver.h
@@ -133,14 +133,12 @@ public:
   // project velocity onto divergence-free field with satisfaction of the no-splip condition
   PetscErrorCode projectionStep();
 
-  // print info about simulation
-  PetscErrorCode printInfo();
   // read fluxes from files
   PetscErrorCode readFluxes();
   // read pressure field from file
   virtual PetscErrorCode readLambda();
-  // write grid coordinates into file
-  PetscErrorCode writeGrid();
+  // write grid stations of the different field variables into HDF5 files
+  PetscErrorCode writeGrids();
   // write fluxes into files
   PetscErrorCode writeFluxes();
   // write pressure field into file

--- a/src/solvers/navierStokes/NavierStokesSolver.h
+++ b/src/solvers/navierStokes/NavierStokesSolver.h
@@ -134,15 +134,19 @@ public:
   PetscErrorCode projectionStep();
 
   // read fluxes from files
-  PetscErrorCode readFluxes();
+  PetscErrorCode readFluxes(std::string directory);
+  // read velocity components from files
+  PetscErrorCode readVelocities(std::string directory);
   // read pressure field from file
-  virtual PetscErrorCode readLambda();
+  virtual PetscErrorCode readLambda(std::string directory);
   // write grid stations of the different field variables into HDF5 files
   PetscErrorCode writeGrids();
   // write fluxes into files
-  PetscErrorCode writeFluxes();
+  PetscErrorCode writeFluxes(std::string directory);
+  // write velocity components into files
+  PetscErrorCode writeVelocities(std::string directory);
   // write pressure field into file
-  virtual PetscErrorCode writeLambda();
+  virtual PetscErrorCode writeLambda(std::string directory);
   // write KSP iteration counts into file
   PetscErrorCode writeIterationCounts();
   

--- a/src/solvers/navierStokes/NavierStokesSolver.h
+++ b/src/solvers/navierStokes/NavierStokesSolver.h
@@ -176,6 +176,8 @@ public:
 
   // write numerical solution into respective files
   virtual PetscErrorCode writeData();
+  // read numerical solution from files
+  PetscErrorCode readData();
 
 }; // NavierStokesSolver
 

--- a/src/solvers/navierStokes/NavierStokesSolver.h
+++ b/src/solvers/navierStokes/NavierStokesSolver.h
@@ -139,8 +139,10 @@ public:
   PetscErrorCode readVelocities(std::string directory);
   // read pressure field from file
   virtual PetscErrorCode readLambda(std::string directory);
+#ifdef PETSC_HAVE_HDF5
   // write grid stations of the different field variables into HDF5 files
   PetscErrorCode writeGrids();
+#endif
   // write fluxes into files
   PetscErrorCode writeFluxes(std::string directory);
   // write velocity components into files

--- a/src/solvers/navierStokes/inline/initializeFluxes.inl
+++ b/src/solvers/navierStokes/inline/initializeFluxes.inl
@@ -7,20 +7,11 @@
 
 
 /**
- * \brief Computes the initial fluxes.
+ * \brief Initializes the fluxes.
  * 
  * Initialize the flux vector with the values of the velocity fluxes at the first
  * time step. The initial values of the velocity from which the fluxes are 
  * calculated are read from the FlowDescription object `flowDesc`.
- *
- * In the input file `simulationParameters.yaml`, if `startStep` is higher than 
- * `0`, the simulation is restarted, reading the numerical solution at the 
- * time-step specified.
- *
- * In the input file `flowDescription.yaml`, if the parameter `initialCustomField` 
- * is set to `true`, the initial field is read from the solution folder `0000000`.
- * However if the input `startStep` is higher than `0`, the simulation is considered
- * as restarted.
  */
 template <PetscInt dim>
 PetscErrorCode NavierStokesSolver<dim>::initializeFluxes()
@@ -35,56 +26,51 @@ PetscErrorCode NavierStokesSolver<2>::initializeFluxes()
 {
   PetscErrorCode ierr;
   
-  if (parameters->startStep > 0 || flow->initialCustomField)
+  PetscFunctionBeginUser;
+
+  PetscInt i, j,           // loop indices
+           m, n,           // local number of nodes along each direction
+           mstart, nstart; // starting indices
+
+  // get access to individual packed vectors in their global representation
+  Vec qxGlobal, qyGlobal;
+  ierr = DMCompositeGetAccess(qPack, q, &qxGlobal, &qyGlobal); CHKERRQ(ierr);
+
+  // fluxes in x-direction
+  PetscReal **qx;
+  ierr = DMDAVecGetArray(uda, qxGlobal, &qx); CHKERRQ(ierr);
+  ierr = DMDAGetCorners(uda, &mstart, &nstart, NULL, &m, &n, NULL); CHKERRQ(ierr);
+  for (j=nstart; j<nstart+n; j++)
   {
-    ierr = readFluxes(); CHKERRQ(ierr);
+    for (i=mstart; i<mstart+m; i++)
+    {
+      qx[j][i] = flow->initialVelocity[0] * mesh->dy[j];
+    }
   }
-  else
-  { 
-    PetscInt i, j,           // loop indices
-             m, n,           // local number of nodes along each direction
-             mstart, nstart; // starting indices
-
-    // get access to individual packed vectors in their global representation
-    Vec qxGlobal, qyGlobal;
-    ierr = DMCompositeGetAccess(qPack, q, &qxGlobal, &qyGlobal); CHKERRQ(ierr);
-
-    // fluxes in x-direction
-    PetscReal **qx;
-    ierr = DMDAVecGetArray(uda, qxGlobal, &qx); CHKERRQ(ierr);
-    ierr = DMDAGetCorners(uda, &mstart, &nstart, NULL, &m, &n, NULL); CHKERRQ(ierr);
-    for (j=nstart; j<nstart+n; j++)
+  ierr = DMDAVecRestoreArray(uda, qxGlobal, &qx); CHKERRQ(ierr);
+  // fluxes in y-direction
+  PetscReal **qy;
+  ierr = DMDAVecGetArray(vda, qyGlobal, &qy); CHKERRQ(ierr);
+  ierr = DMDAGetCorners(vda, &mstart, &nstart, NULL, &m, &n, NULL); CHKERRQ(ierr);
+  for (j=nstart; j<nstart+n; j++)
+  {
+    for (i=mstart; i<mstart+m; i++)
     {
-      for (i=mstart; i<mstart+m; i++)
-      {
-        qx[j][i] = flow->initialVelocity[0] * mesh->dy[j];
-      }
+      qy[j][i] = flow->initialVelocity[1] * mesh->dx[i];
     }
-    ierr = DMDAVecRestoreArray(uda, qxGlobal, &qx); CHKERRQ(ierr);
-    // fluxes in y-direction
-    PetscReal **qy;
-    ierr = DMDAVecGetArray(vda, qyGlobal, &qy); CHKERRQ(ierr);
-    ierr = DMDAGetCorners(vda, &mstart, &nstart, NULL, &m, &n, NULL); CHKERRQ(ierr);
-    for (j=nstart; j<nstart+n; j++)
-    {
-      for (i=mstart; i<mstart+m; i++)
-      {
-        qy[j][i] = flow->initialVelocity[1] * mesh->dx[i];
-      }
-    }
-    ierr = DMDAVecRestoreArray(vda, qyGlobal, &qy); CHKERRQ(ierr);
+  }
+  ierr = DMDAVecRestoreArray(vda, qyGlobal, &qy); CHKERRQ(ierr);
 
-    ierr = DMCompositeRestoreAccess(qPack, q, &qxGlobal, &qyGlobal); CHKERRQ(ierr);
+  ierr = DMCompositeRestoreAccess(qPack, q, &qxGlobal, &qyGlobal); CHKERRQ(ierr);
 
-    if (flow->perturbationAmplitude != 0.0)
-    {
-      ierr = addInitialPerturbation(); CHKERRQ(ierr);
-    }
+  if (flow->perturbationAmplitude != 0.0)
+  {
+    ierr = addInitialPerturbation(); CHKERRQ(ierr);
   }
 
   ierr = DMCompositeScatter(qPack, q, qxLocal, qyLocal); CHKERRQ(ierr);
 
-  return 0;
+  PetscFunctionReturn(0);
 } // initializeFluxes
 
 
@@ -94,75 +80,70 @@ PetscErrorCode NavierStokesSolver<3>::initializeFluxes()
 {
   PetscErrorCode ierr;
 
-  if (parameters->startStep > 0 || flow->initialCustomField)
+  PetscFunctionBeginUser;
+
+  PetscInt i, j, k,                // loop indices
+           m, n, p,                // local number of nodes along each direction
+           mstart, nstart, pstart; // starting indices
+
+  // get access to individual packed vectors in their global representation
+  Vec qxGlobal, qyGlobal, qzGlobal;
+  ierr = DMCompositeGetAccess(qPack, q, &qxGlobal, &qyGlobal, &qzGlobal); CHKERRQ(ierr);
+  
+  // fluxes in x-direction
+  PetscReal ***qx;
+  ierr = DMDAVecGetArray(uda, qxGlobal, &qx); CHKERRQ(ierr);
+  ierr = DMDAGetCorners(uda, &mstart, &nstart, &pstart, &m, &n, &p); CHKERRQ(ierr);
+  for (k=pstart; k<pstart+p; k++)
   {
-    ierr = readFluxes(); CHKERRQ(ierr);
+    for (j=nstart; j<nstart+n; j++)
+    {
+      for (i=mstart; i<mstart+m; i++)
+      {
+        qx[k][j][i] = flow->initialVelocity[0] * (mesh->dy[j]*mesh->dz[k]);
+      }
+    }
   }
-  else
+  ierr = DMDAVecRestoreArray(uda, qxGlobal, &qx); CHKERRQ(ierr);
+  // fluxes in y-direction
+  PetscReal ***qy;
+  ierr = DMDAVecGetArray(vda, qyGlobal, &qy); CHKERRQ(ierr);
+  ierr = DMDAGetCorners(vda, &mstart, &nstart, &pstart, &m, &n, &p); CHKERRQ(ierr);
+  for (k=pstart; k<pstart+p; k++)
   {
-    PetscInt i, j, k,                // loop indices
-             m, n, p,                // local number of nodes along each direction
-             mstart, nstart, pstart; // starting indices
-
-    // get access to individual packed vectors in their global representation
-    Vec qxGlobal, qyGlobal, qzGlobal;
-    ierr = DMCompositeGetAccess(qPack, q, &qxGlobal, &qyGlobal, &qzGlobal); CHKERRQ(ierr);
-    
-    // fluxes in x-direction
-    PetscReal ***qx;
-    ierr = DMDAVecGetArray(uda, qxGlobal, &qx); CHKERRQ(ierr);
-    ierr = DMDAGetCorners(uda, &mstart, &nstart, &pstart, &m, &n, &p); CHKERRQ(ierr);
-    for (k=pstart; k<pstart+p; k++)
+    for (j=nstart; j<nstart+n; j++)
     {
-      for (j=nstart; j<nstart+n; j++)
+      for (i=mstart; i<mstart+m; i++)
       {
-        for (i=mstart; i<mstart+m; i++)
-        {
-          qx[k][j][i] = flow->initialVelocity[0] * (mesh->dy[j]*mesh->dz[k]);
-        }
+        qy[k][j][i] = flow->initialVelocity[1] * (mesh->dx[i]*mesh->dz[k]);
       }
     }
-    ierr = DMDAVecRestoreArray(uda, qxGlobal, &qx); CHKERRQ(ierr);
-    // fluxes in y-direction
-    PetscReal ***qy;
-    ierr = DMDAVecGetArray(vda, qyGlobal, &qy); CHKERRQ(ierr);
-    ierr = DMDAGetCorners(vda, &mstart, &nstart, &pstart, &m, &n, &p); CHKERRQ(ierr);
-    for (k=pstart; k<pstart+p; k++)
+  }
+  ierr = DMDAVecRestoreArray(vda, qyGlobal, &qy); CHKERRQ(ierr);
+  // fluxes in z-direction
+  PetscReal ***qz;
+  ierr = DMDAVecGetArray(wda, qzGlobal, &qz); CHKERRQ(ierr);
+  ierr = DMDAGetCorners(wda, &mstart, &nstart, &pstart, &m, &n, &p); CHKERRQ(ierr);
+  for (k=pstart; k<pstart+p; k++)
+  {
+    for (j=nstart; j<nstart+n; j++)
     {
-      for (j=nstart; j<nstart+n; j++)
-      {
-        for (i=mstart; i<mstart+m; i++)
-        {
-          qy[k][j][i] = flow->initialVelocity[1] * (mesh->dx[i]*mesh->dz[k]);
-        }
+      for (i=mstart; i<mstart+m; i++)
+      { 
+        qz[k][j][i] = flow->initialVelocity[2] * (mesh->dx[i]*mesh->dy[j]);
       }
     }
-    ierr = DMDAVecRestoreArray(vda, qyGlobal, &qy); CHKERRQ(ierr);
-    // fluxes in z-direction
-    PetscReal ***qz;
-    ierr = DMDAVecGetArray(wda, qzGlobal, &qz); CHKERRQ(ierr);
-    ierr = DMDAGetCorners(wda, &mstart, &nstart, &pstart, &m, &n, &p); CHKERRQ(ierr);
-    for (k=pstart; k<pstart+p; k++)
-    {
-      for (j=nstart; j<nstart+n; j++)
-      {
-        for (i=mstart; i<mstart+m; i++)
-        { 
-          qz[k][j][i] = flow->initialVelocity[2] * (mesh->dx[i]*mesh->dy[j]);
-        }
-      }
-    }
-    ierr = DMDAVecRestoreArray(wda, qzGlobal, &qz); CHKERRQ(ierr);
+  }
+  ierr = DMDAVecRestoreArray(wda, qzGlobal, &qz); CHKERRQ(ierr);
 
-    ierr = DMCompositeRestoreAccess(qPack, q, &qxGlobal, &qyGlobal, &qzGlobal); CHKERRQ(ierr);
+  ierr = DMCompositeRestoreAccess(qPack, q, &qxGlobal, &qyGlobal, &qzGlobal); CHKERRQ(ierr);
 
-    if (flow->perturbationAmplitude != 0.0)
-    {
-      ierr = addInitialPerturbation(); CHKERRQ(ierr);
-    }
+  if (flow->perturbationAmplitude != 0.0)
+  {
+    ierr = addInitialPerturbation(); CHKERRQ(ierr);
   }
   
   ierr = DMCompositeScatter(qPack, q, qxLocal, qyLocal, qzLocal); CHKERRQ(ierr);
 
-  return 0;
+  PetscFunctionReturn(0);
 } // initializeFluxes

--- a/src/solvers/navierStokes/inline/initializeLambda.inl
+++ b/src/solvers/navierStokes/inline/initializeLambda.inl
@@ -6,20 +6,17 @@
  */
 
 /**
- * \brief Initializes the lambda vector that contains the pressure.
+ * \brief Initializes the lambda vector that contains the pressure with zeros.
  *
- * Only reads the pressure field when the simulation is restarted or when a 
- * custom initial field is used.
  */
 template <PetscInt dim>
 PetscErrorCode NavierStokesSolver<dim>::initializeLambda()
 {
   PetscErrorCode ierr;
 
-  if (parameters->startStep > 0 || flow->initialCustomField)
-  {
-    ierr = readLambda(); CHKERRQ(ierr);
-  }
+  PetscFunctionBeginUser;
 
-  return 0;
+  ierr = VecSet(lambda, 0.0); CHKERRQ(ierr);
+
+  PetscFunctionReturn(0);
 } // initializeLambda

--- a/src/solvers/navierStokes/inline/io.inl
+++ b/src/solvers/navierStokes/inline/io.inl
@@ -10,6 +10,34 @@
 
 
 /**
+ * \brief Reads the numerical solution from files.
+ */
+template <PetscInt dim>
+PetscErrorCode NavierStokesSolver<dim>::readData()
+{
+  PetscErrorCode ierr;
+
+  PetscFunctionBeginUser;
+
+  ierr = PetscPrintf(PETSC_COMM_WORLD,
+                     "\n[time-step %d] Reading numerical solution from files... ",
+                     timeStep); CHKERRQ(ierr);
+
+  // get solution directory
+  std::stringstream ss;
+  ss << parameters->directory << "/" << std::setfill('0') << std::setw(7) << timeStep;
+  std::string solutionDirectory = ss.str();
+
+  ierr = readFluxes(solutionDirectory); CHKERRQ(ierr);
+  ierr = writeLambda(solutionDirectory); CHKERRQ(ierr);
+
+  ierr = PetscPrintf(PETSC_COMM_WORLD, "done\n"); CHKERRQ(ierr);
+
+  PetscFunctionReturn(0);
+} // readData
+
+
+/**
  * \brief Read flux fields from files.
  *
  * \param directory Directory where to read the flux fields.

--- a/src/solvers/navierStokes/inline/io.inl
+++ b/src/solvers/navierStokes/inline/io.inl
@@ -61,12 +61,12 @@ PetscErrorCode NavierStokesSolver<dim>::readFluxes(std::string directory)
   PetscFunctionBeginUser;
 
   // get type of viewer depending on output format prescribed
-  if (parameters->fileFormat == "hdf5")
+  if (parameters->outputFormat == "hdf5")
   {
     viewerType = PETSCVIEWERHDF5;
     fileExtension = "h5";
   }
-  else if (parameters->fileFormat == "binary")
+  else if (parameters->outputFormat == "binary")
   {
     viewerType = PETSCVIEWERBINARY;
     fileExtension = "dat";
@@ -142,12 +142,12 @@ PetscErrorCode NavierStokesSolver<dim>::readVelocities(std::string directory)
   PetscFunctionBeginUser;
 
   // define the type of viewer and the file extension
-  if (parameters->fileFormat == "hdf5")
+  if (parameters->outputFormat == "hdf5")
   {
     viewerType = PETSCVIEWERHDF5;
     fileExtension = "h5";
   }
-  else if (parameters->fileFormat == "binary")
+  else if (parameters->outputFormat == "binary")
   {
     viewerType = PETSCVIEWERBINARY;
     fileExtension = "dat";
@@ -229,12 +229,12 @@ PetscErrorCode NavierStokesSolver<dim>::readLambda(std::string directory)
   PetscFunctionBeginUser;
 
   // define the type of viewer and the file extension
-  if (parameters->fileFormat == "hdf5")
+  if (parameters->outputFormat == "hdf5")
   {
     viewerType = PETSCVIEWERHDF5;
     fileExtension = "h5";
   }
-  else if (parameters->fileFormat == "binary")
+  else if (parameters->outputFormat == "binary")
   {
     viewerType = PETSCVIEWERBINARY;
     fileExtension = "dat";
@@ -347,12 +347,12 @@ PetscErrorCode NavierStokesSolver<dim>::writeFluxes(std::string directory)
   PetscFunctionBeginUser;
 
   // define the type of viewer and the file extension
-  if (parameters->fileFormat == "hdf5")
+  if (parameters->outputFormat == "hdf5")
   {
     viewerType = PETSCVIEWERHDF5;
     fileExtension = "h5";
   }
-  else if (parameters->fileFormat == "binary")
+  else if (parameters->outputFormat == "binary")
   {
     viewerType = PETSCVIEWERBINARY;
     fileExtension = "dat";
@@ -428,12 +428,12 @@ PetscErrorCode NavierStokesSolver<dim>::writeVelocities(std::string directory)
   PetscFunctionBeginUser;
 
   // define the type of viewer and the file extension
-  if (parameters->fileFormat == "hdf5")
+  if (parameters->outputFormat == "hdf5")
   {
     viewerType = PETSCVIEWERHDF5;
     fileExtension = "h5";
   }
-  else if (parameters->fileFormat == "binary")
+  else if (parameters->outputFormat == "binary")
   {
     viewerType = PETSCVIEWERBINARY;
     fileExtension = "dat";
@@ -515,12 +515,12 @@ PetscErrorCode NavierStokesSolver<dim>::writeLambda(std::string directory)
   PetscFunctionBeginUser;
 
   // define the type of viewer and the file extension
-  if (parameters->fileFormat == "hdf5")
+  if (parameters->outputFormat == "hdf5")
   {
     viewerType = PETSCVIEWERHDF5;
     fileExtension = "h5";
   }
-  else if (parameters->fileFormat == "binary")
+  else if (parameters->outputFormat == "binary")
   {
     viewerType = PETSCVIEWERBINARY;
     fileExtension = "dat";

--- a/src/solvers/navierStokes/inline/io.inl
+++ b/src/solvers/navierStokes/inline/io.inl
@@ -28,8 +28,15 @@ PetscErrorCode NavierStokesSolver<dim>::readData()
   ss << parameters->directory << "/" << std::setfill('0') << std::setw(7) << timeStep;
   std::string solutionDirectory = ss.str();
 
-  ierr = readFluxes(solutionDirectory); CHKERRQ(ierr);
-  ierr = writeLambda(solutionDirectory); CHKERRQ(ierr);
+  if (parameters->outputFlux)
+  {
+    ierr = readFluxes(solutionDirectory); CHKERRQ(ierr);
+  }
+  else if (parameters->outputVelocity)
+  {
+    ierr = readVelocities(solutionDirectory); CHKERRQ(ierr);
+  }
+  ierr = readLambda(solutionDirectory); CHKERRQ(ierr);
 
   ierr = PetscPrintf(PETSC_COMM_WORLD, "done\n"); CHKERRQ(ierr);
 
@@ -275,8 +282,14 @@ PetscErrorCode NavierStokesSolver<dim>::writeData()
     std::string solutionDirectory = ss.str();
     mkdir(solutionDirectory.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 
-    ierr = writeFluxes(solutionDirectory); CHKERRQ(ierr);
-    ierr = writeVelocities(solutionDirectory); CHKERRQ(ierr);
+    if (parameters->outputFlux)
+    {
+      ierr = writeFluxes(solutionDirectory); CHKERRQ(ierr);
+    }
+    if (parameters->outputVelocity)
+    {
+      ierr = writeVelocities(solutionDirectory); CHKERRQ(ierr);
+    }
     ierr = writeLambda(solutionDirectory); CHKERRQ(ierr);
 
     ierr = PetscPrintf(PETSC_COMM_WORLD, "done\n"); CHKERRQ(ierr);

--- a/src/solvers/navierStokes/inline/io.inl
+++ b/src/solvers/navierStokes/inline/io.inl
@@ -299,6 +299,7 @@ PetscErrorCode NavierStokesSolver<dim>::writeData()
 } // writeData
 
 
+#ifdef PETSC_HAVE_HDF5
 /**
  * \brief Writes grid stations of the different field variables in HDF5 files.
  */
@@ -328,6 +329,7 @@ PetscErrorCode NavierStokesSolver<dim>::writeGrids()
 
   PetscFunctionReturn(0);
 } // writeGrids
+#endif
 
 
 /**

--- a/src/solvers/navierStokes/inline/io.inl
+++ b/src/solvers/navierStokes/inline/io.inl
@@ -185,16 +185,20 @@ PetscErrorCode NavierStokesSolver<dim>::writeGrids()
                      "\n[time-step %d] Writing grids into files... ",
                      timeStep); CHKERRQ(ierr);
 
-  std::string filePath = parameters->directory + "/grid_qx.h5";
+  // create subfolder `grids`
+  std::string subfolder = parameters->directory + "/grids";
+  mkdir(subfolder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+
+  std::string filePath = subfolder + "/grid_qx.h5";
   ierr = mesh->write(filePath, STAGGERED_MODE_X); CHKERRQ(ierr);
-  filePath = parameters->directory + "/grid_qy.h5";
+  filePath = subfolder + "/grid_qy.h5";
   ierr = mesh->write(filePath, STAGGERED_MODE_Y); CHKERRQ(ierr);
   if (dim == 3)
   {
-    filePath = parameters->directory + "/grid_qz.h5";
+    filePath = subfolder + "/grid_qz.h5";
     ierr = mesh->write(filePath, STAGGERED_MODE_Z); CHKERRQ(ierr);
   }
-  filePath = parameters->directory + "/grid_phi.h5";
+  filePath = subfolder + "/grid_phi.h5";
   ierr = mesh->write(filePath, CELL_CENTERED); CHKERRQ(ierr);
 
   ierr = PetscPrintf(PETSC_COMM_WORLD, "done.\n"); CHKERRQ(ierr);

--- a/src/solvers/tairaColonius/TairaColoniusSolver.cpp
+++ b/src/solvers/tairaColonius/TairaColoniusSolver.cpp
@@ -44,13 +44,11 @@ PetscErrorCode TairaColoniusSolver<dim>::initialize()
 
   ierr = PetscLogStagePush(NavierStokesSolver<dim>::stageInitialize); CHKERRQ(ierr);
 
-  ierr = NavierStokesSolver<dim>::printInfo(); CHKERRQ(ierr);
   ierr = initializeBodies(); CHKERRQ(ierr);
   ierr = calculateCellIndices(); CHKERRQ(ierr);
   ierr = createDMs(); CHKERRQ(ierr);
   ierr = createGlobalMappingBodies(); CHKERRQ(ierr);
   ierr = NavierStokesSolver<dim>::initializeCommon(); CHKERRQ(ierr);
-  ierr = NavierStokesSolver<dim>::writeGrid(); CHKERRQ(ierr);
 
   ierr = PetscLogStagePop(); CHKERRQ(ierr);
 

--- a/src/solvers/tairaColonius/TairaColoniusSolver.h
+++ b/src/solvers/tairaColonius/TairaColoniusSolver.h
@@ -52,9 +52,9 @@ public:
   PetscErrorCode createGlobalMappingBodies();
   PetscErrorCode calculateForce();
   
-  PetscErrorCode readLambda();
+  PetscErrorCode readLambda(std::string directory);
   PetscErrorCode writeData();
-  PetscErrorCode writeLambda();
+  PetscErrorCode writeLambda(std::string directory);
   PetscErrorCode writeForces();
 
   PetscReal dhRoma(PetscReal x, PetscReal h);

--- a/src/solvers/tairaColonius/inline/io.inl
+++ b/src/solvers/tairaColonius/inline/io.inl
@@ -6,29 +6,22 @@
 
 
 /**
- * \brief Reads the pressure field and body forces from saved numerical solution file.
+ * \brief Reads the pressure field and body forces from files.
+ *
+ * \param directory Directory where to read the solutions.
  */
 template <PetscInt dim>
-PetscErrorCode TairaColoniusSolver<dim>::readLambda()
+PetscErrorCode TairaColoniusSolver<dim>::readLambda(std::string directory)
 {
   PetscErrorCode ierr;
-
-  ierr = PetscPrintf(PETSC_COMM_WORLD,
-                     "\n[time-step %d] Reading pressure and body forces from file... ",
-                     NavierStokesSolver<dim>::timeStep); CHKERRQ(ierr);
-
-  // get solution directory: 7 characters long, time-step preprend by leading zeros
-  std::stringstream ss;
-  ss << NavierStokesSolver<dim>::parameters->directory << "/" << std::setfill('0') << std::setw(7) << NavierStokesSolver<dim>::timeStep;
-  std::string solutionDirectory = ss.str();
-
-  // get access to the pressure vector from the composite vector
   Vec phi, fTilde;
-  ierr = DMCompositeGetAccess(NavierStokesSolver<dim>::lambdaPack, NavierStokesSolver<dim>::lambda, &phi, &fTilde); CHKERRQ(ierr);
-
   PetscViewer viewer;
   PetscViewerType viewerType;
-  std::string fileExtension;
+  std::string filePath, fileExtension;
+
+  PetscFunctionBeginUser;
+
+  // define the type of viewer and the file extension
   if (NavierStokesSolver<dim>::parameters->fileFormat == "hdf5")
   {
     viewerType = PETSCVIEWERHDF5;
@@ -39,9 +32,11 @@ PetscErrorCode TairaColoniusSolver<dim>::readLambda()
     viewerType = PETSCVIEWERBINARY;
     fileExtension = "dat";
   }
+  
+  ierr = DMCompositeGetAccess(NavierStokesSolver<dim>::lambdaPack, NavierStokesSolver<dim>::lambda, &phi, &fTilde); CHKERRQ(ierr);
 
   // read pressure field
-  std::string filePath = solutionDirectory + "/phi." + fileExtension;
+  filePath = directory + "/phi." + fileExtension;
   ierr = PetscObjectSetName((PetscObject) phi, "phi"); CHKERRQ(ierr);
   ierr = PetscViewerCreate(PETSC_COMM_WORLD, &viewer); CHKERRQ(ierr); 
   ierr = PetscViewerSetType(viewer, viewerType); CHKERRQ(ierr);
@@ -49,11 +44,10 @@ PetscErrorCode TairaColoniusSolver<dim>::readLambda()
   ierr = PetscViewerFileSetName(viewer, filePath.c_str()); CHKERRQ(ierr);
   ierr = VecLoad(phi, viewer); CHKERRQ(ierr);
   ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
-
-  // read body forces iff restarting the simulation
+  // read body forces if restarting the simulation
   if (NavierStokesSolver<dim>::timeStep > 0)
   {
-    filePath = solutionDirectory + "/fTilde." + fileExtension;
+    filePath = directory + "/fTilde." + fileExtension;
     ierr = PetscObjectSetName((PetscObject) fTilde, "fTilde"); CHKERRQ(ierr);
     ierr = PetscViewerCreate(PETSC_COMM_WORLD, &viewer); CHKERRQ(ierr); 
     ierr = PetscViewerSetType(viewer, viewerType); CHKERRQ(ierr);
@@ -65,54 +59,44 @@ PetscErrorCode TairaColoniusSolver<dim>::readLambda()
 
   ierr = DMCompositeRestoreAccess(NavierStokesSolver<dim>::lambdaPack, NavierStokesSolver<dim>::lambda, &phi, &fTilde); CHKERRQ(ierr);
 
-  ierr = PetscPrintf(PETSC_COMM_WORLD, "done.\n"); CHKERRQ(ierr);
-
-  return 0;
+  PetscFunctionReturn(0);
 } // readLambda
 
 
 /**
- * \brief Writes the numerical solution into respective files.
+ * \brief Writes the numerical solution into files.
  */
 template <PetscInt dim>
 PetscErrorCode TairaColoniusSolver<dim>::writeData()
 {
   PetscErrorCode ierr;
 
+  PetscFunctionBeginUser;
+
   ierr = calculateForce(); CHKERRQ(ierr);
   ierr = writeForces(); CHKERRQ(ierr);
   ierr = NavierStokesSolver<dim>::writeData(); CHKERRQ(ierr);
 
-  return 0;
+  PetscFunctionReturn(0);
 } // writeData
 
 
 /**
- * \brief Writes the pressure field and the body forces into files 
- *        located in solution directory.
+ * \brief Writes the pressure field and the body forces into files.
+ *
+ * \param directory Directory where to write the solutions.
  */
 template <PetscInt dim>
-PetscErrorCode TairaColoniusSolver<dim>::writeLambda()
+PetscErrorCode TairaColoniusSolver<dim>::writeLambda(std::string directory)
 {
   PetscErrorCode ierr;
-
-  ierr = PetscPrintf(PETSC_COMM_WORLD,
-                     "\n[time-step %d] Writing pressure and body forces into file... ",
-                     NavierStokesSolver<dim>::timeStep); CHKERRQ(ierr);
-
-  // create the solution directory
-  std::stringstream ss;
-  ss << NavierStokesSolver<dim>::parameters->directory << "/" << std::setfill('0') << std::setw(7) << NavierStokesSolver<dim>::timeStep;
-  std::string solutionDirectory = ss.str();
-  mkdir(solutionDirectory.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-
-  // get access to the pressure vector from the composite vector
   Vec phi, fTilde;
-  ierr = DMCompositeGetAccess(NavierStokesSolver<dim>::lambdaPack, NavierStokesSolver<dim>::lambda, &phi, &fTilde); CHKERRQ(ierr);
-
   PetscViewer viewer;
   PetscViewerType viewerType;
-  std::string fileExtension;
+  std::string filePath, fileExtension;
+
+  PetscFunctionBeginUser;
+
   if (NavierStokesSolver<dim>::parameters->fileFormat == "hdf5")
   {
     viewerType = PETSCVIEWERHDF5;
@@ -124,8 +108,10 @@ PetscErrorCode TairaColoniusSolver<dim>::writeLambda()
     fileExtension = "dat";
   }
 
+  ierr = DMCompositeGetAccess(NavierStokesSolver<dim>::lambdaPack, NavierStokesSolver<dim>::lambda, &phi, &fTilde); CHKERRQ(ierr);
+
   // write pressure field
-  std::string filePath = solutionDirectory + "/phi." + fileExtension;
+  filePath = directory + "/phi." + fileExtension;
   ierr = PetscObjectSetName((PetscObject) phi, "phi"); CHKERRQ(ierr);
   ierr = PetscViewerCreate(PETSC_COMM_WORLD, &viewer); CHKERRQ(ierr); 
   ierr = PetscViewerSetType(viewer, viewerType); CHKERRQ(ierr);
@@ -133,9 +119,8 @@ PetscErrorCode TairaColoniusSolver<dim>::writeLambda()
   ierr = PetscViewerFileSetName(viewer, filePath.c_str()); CHKERRQ(ierr);
   ierr = VecView(phi, viewer); CHKERRQ(ierr);
   ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
-
   // write body forces
-  filePath = solutionDirectory + "/fTilde." + fileExtension;
+  filePath = directory + "/fTilde." + fileExtension;
   ierr = PetscObjectSetName((PetscObject) fTilde, "fTilde"); CHKERRQ(ierr);
   ierr = PetscViewerCreate(PETSC_COMM_WORLD, &viewer); CHKERRQ(ierr); 
   ierr = PetscViewerSetType(viewer, viewerType); CHKERRQ(ierr);
@@ -146,9 +131,7 @@ PetscErrorCode TairaColoniusSolver<dim>::writeLambda()
 
   ierr = DMCompositeRestoreAccess(NavierStokesSolver<dim>::lambdaPack, NavierStokesSolver<dim>::lambda, &phi, &fTilde); CHKERRQ(ierr);
 
-  ierr = PetscPrintf(PETSC_COMM_WORLD, "done.\n"); CHKERRQ(ierr);
-
-  return 0;
+  PetscFunctionReturn(0);
 } // writeLambda
 
 

--- a/src/solvers/tairaColonius/inline/io.inl
+++ b/src/solvers/tairaColonius/inline/io.inl
@@ -22,12 +22,12 @@ PetscErrorCode TairaColoniusSolver<dim>::readLambda(std::string directory)
   PetscFunctionBeginUser;
 
   // define the type of viewer and the file extension
-  if (NavierStokesSolver<dim>::parameters->fileFormat == "hdf5")
+  if (NavierStokesSolver<dim>::parameters->outputFormat == "hdf5")
   {
     viewerType = PETSCVIEWERHDF5;
     fileExtension = "h5";
   }
-  else if (NavierStokesSolver<dim>::parameters->fileFormat == "binary")
+  else if (NavierStokesSolver<dim>::parameters->outputFormat == "binary")
   {
     viewerType = PETSCVIEWERBINARY;
     fileExtension = "dat";
@@ -97,12 +97,12 @@ PetscErrorCode TairaColoniusSolver<dim>::writeLambda(std::string directory)
 
   PetscFunctionBeginUser;
 
-  if (NavierStokesSolver<dim>::parameters->fileFormat == "hdf5")
+  if (NavierStokesSolver<dim>::parameters->outputFormat == "hdf5")
   {
     viewerType = PETSCVIEWERHDF5;
     fileExtension = "h5";
   }
-  else if (NavierStokesSolver<dim>::parameters->fileFormat == "binary")
+  else if (NavierStokesSolver<dim>::parameters->outputFormat == "binary")
   {
     viewerType = PETSCVIEWERBINARY;
     fileExtension = "dat";

--- a/src/utilities/CartesianMesh.cpp
+++ b/src/utilities/CartesianMesh.cpp
@@ -212,6 +212,7 @@ PetscErrorCode CartesianMesh::write(std::string filePath)
 } // write
 
 
+#ifdef PETSC_HAVE_HDF5
 /**
  * \brief Writes the grid stations into a HDF5 file.
  *
@@ -305,6 +306,7 @@ PetscErrorCode CartesianMesh::write(std::string filePath, StaggeredMode mode)
 
   return 0;
 } // write
+#endif
 
 
 /**

--- a/src/utilities/CartesianMesh.cpp
+++ b/src/utilities/CartesianMesh.cpp
@@ -224,13 +224,13 @@ PetscErrorCode CartesianMesh::write(std::string filePath, StaggeredMode mode)
   PetscReal value;
   PetscViewer viewer;
   Vec xs, ys, zs;
-
   PetscInt rank;
+
   ierr = MPI_Comm_rank(PETSC_COMM_WORLD, &rank); CHKERRQ(ierr);
 
   if (rank == 0)
   {
-    ierr = PetscViewerHDF5Open(PETSC_COMM_WORLD, filePath.c_str(), FILE_MODE_WRITE, &viewer); CHKERRQ(ierr);
+    ierr = PetscViewerHDF5Open(PETSC_COMM_SELF, filePath.c_str(), FILE_MODE_WRITE, &viewer); CHKERRQ(ierr);
     // stations along a gridline in the x-direction
     if (mode == STAGGERED_MODE_X)
     {
@@ -239,7 +239,7 @@ PetscErrorCode CartesianMesh::write(std::string filePath, StaggeredMode mode)
       {
         value = x[i+1];
         ierr = VecSetValue(xs, i, value, INSERT_VALUES); CHKERRQ(ierr);
-      }  
+      }
     }
     else
     {

--- a/src/utilities/CartesianMesh.cpp
+++ b/src/utilities/CartesianMesh.cpp
@@ -8,8 +8,11 @@
 #include "CartesianMesh.h"
 
 #include <fstream>
+#include <iomanip>
 
 #include "yaml-cpp/yaml.h"
+#include <petscvec.h>
+#include <petscviewerhdf5.h>
 
 
 /**
@@ -164,6 +167,144 @@ void CartesianMesh::initialize(std::string filePath)
   PetscPrintf(PETSC_COMM_WORLD, "done.\n");
 
 } // initialize
+
+
+/**
+ * \brief Writes grid points into file.
+ *
+ * \param filePath Path of the file to write
+ */
+PetscErrorCode CartesianMesh::write(std::string filePath)
+{
+  PetscErrorCode ierr;
+
+  ierr = PetscPrintf(PETSC_COMM_WORLD, "\nWriting grid into file... "); CHKERRQ(ierr);
+
+  PetscInt rank;
+  ierr = MPI_Comm_rank(PETSC_COMM_WORLD, &rank); CHKERRQ(ierr);
+
+  if (rank == 0)
+  {
+    std::ofstream streamFile(filePath);
+    if (nz == 0)
+    {
+      streamFile << nx << '\t' << ny << '\n';
+    }
+    else
+    {
+      streamFile << nx << '\t' << ny << '\t' << nz << '\n';
+    }
+    for (std::vector<PetscReal>::const_iterator i=x.begin(); i!=x.end(); ++i)
+      streamFile << std::setprecision(16) << *i << '\n';
+    for (std::vector<PetscReal>::const_iterator i=y.begin(); i!=y.end(); ++i)
+      streamFile << std::setprecision(16) << *i << '\n';
+    if (nz > 0)
+    {  
+      for (std::vector<PetscReal>::const_iterator i=z.begin(); i!=z.end(); ++i)
+        streamFile << std::setprecision(16) << *i << '\n';
+    }
+    streamFile.close();
+  }
+  
+  ierr = PetscPrintf(PETSC_COMM_WORLD, "done.\n"); CHKERRQ(ierr);
+
+  return 0;
+} // write
+
+
+/**
+ * \brief Writes the grid stations into a HDF5 file.
+ *
+ * \param filePath Path of the file to write
+ * \param mode Staggered mode to define locations of a variable points
+ */
+PetscErrorCode CartesianMesh::write(std::string filePath, StaggeredMode mode)
+{
+  PetscErrorCode ierr;
+  PetscReal value;
+  PetscViewer viewer;
+  Vec xs, ys, zs;
+
+  PetscInt rank;
+  ierr = MPI_Comm_rank(PETSC_COMM_WORLD, &rank); CHKERRQ(ierr);
+
+  if (rank == 0)
+  {
+    ierr = PetscViewerHDF5Open(PETSC_COMM_WORLD, filePath.c_str(), FILE_MODE_WRITE, &viewer); CHKERRQ(ierr);
+    // stations along a gridline in the x-direction
+    if (mode == STAGGERED_MODE_X)
+    {
+      ierr = VecCreateSeq(PETSC_COMM_SELF, nx-1, &xs); CHKERRQ(ierr);
+      for (int i=0; i<nx-1; i++)
+      {
+        value = x[i+1];
+        ierr = VecSetValue(xs, i, value, INSERT_VALUES); CHKERRQ(ierr);
+      }  
+    }
+    else
+    {
+      ierr = VecCreateSeq(PETSC_COMM_SELF, nx, &xs); CHKERRQ(ierr);
+      for (int i=0; i<nx; i++)
+      {
+        value = 0.5 * (x[i] + x[i+1]);
+        ierr = VecSetValue(xs, i, value, INSERT_VALUES); CHKERRQ(ierr);
+      }  
+    }
+    ierr = PetscObjectSetName((PetscObject) xs, "x"); CHKERRQ(ierr);
+    ierr = VecView(xs, viewer); CHKERRQ(ierr);
+    ierr = VecDestroy(&xs); CHKERRQ(ierr);
+    // stations along a gridline in the y-direction
+    if (mode == STAGGERED_MODE_Y)
+    {
+      ierr = VecCreateSeq(PETSC_COMM_SELF, ny-1, &ys); CHKERRQ(ierr);
+      for (int i=0; i<ny-1; i++)
+      {
+        value = y[i+1];
+        ierr = VecSetValue(ys, i, value, INSERT_VALUES); CHKERRQ(ierr);
+      }  
+    }
+    else
+    {
+      ierr = VecCreateSeq(PETSC_COMM_SELF, ny, &ys); CHKERRQ(ierr);
+      for (int i=0; i<ny; i++)
+      {
+        value = 0.5 * (y[i] + y[i+1]);
+        ierr = VecSetValue(ys, i, value, INSERT_VALUES); CHKERRQ(ierr);
+      }  
+    }
+    ierr = PetscObjectSetName((PetscObject) ys, "y"); CHKERRQ(ierr);
+    ierr = VecView(ys, viewer); CHKERRQ(ierr);
+    ierr = VecDestroy(&ys); CHKERRQ(ierr);
+    if (nz > 0)
+    {
+      // stations along a gridline in the z-direction
+      if (mode == STAGGERED_MODE_Z)
+      {
+        ierr = VecCreateSeq(PETSC_COMM_SELF, nz-1, &zs); CHKERRQ(ierr);
+        for (int i=0; i<nz-1; i++)
+        {
+          value = z[i+1];
+          ierr = VecSetValue(zs, i, value, INSERT_VALUES); CHKERRQ(ierr);
+        }  
+      }
+      else
+      {
+        ierr = VecCreateSeq(PETSC_COMM_SELF, nz, &zs); CHKERRQ(ierr);
+        for (int i=0; i<nz; i++)
+        {
+          value = 0.5 * (z[i] + z[i+1]);
+          ierr = VecSetValue(zs, i, value, INSERT_VALUES); CHKERRQ(ierr);
+        }  
+      }
+      ierr = PetscObjectSetName((PetscObject) zs, "z"); CHKERRQ(ierr);
+      ierr = VecView(zs, viewer); CHKERRQ(ierr);
+      ierr = VecDestroy(&zs); CHKERRQ(ierr);
+    }
+    ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
+  }
+
+  return 0;
+} // write
 
 
 /**

--- a/src/utilities/CartesianMesh.h
+++ b/src/utilities/CartesianMesh.h
@@ -43,7 +43,9 @@ public:
   void initialize(std::string filePath);
   // write grid points into file
   PetscErrorCode write(std::string filePath);
+#ifdef PETSC_HAVE_HDF5
   PetscErrorCode write(std::string filePath, StaggeredMode mode);
+#endif
   // print information about Cartesian mesh
   PetscErrorCode printInfo();
 

--- a/src/utilities/CartesianMesh.h
+++ b/src/utilities/CartesianMesh.h
@@ -8,6 +8,8 @@
 #if !defined(CARTESIAN_MESH_H)
 #define CARTESIAN_MESH_H
 
+#include "types.h"
+
 #include <string>
 #include <vector>
 
@@ -39,6 +41,9 @@ public:
   ~CartesianMesh();
   // parse input file and create Cartesian mesh
   void initialize(std::string filePath);
+  // write grid points into file
+  PetscErrorCode write(std::string filePath);
+  PetscErrorCode write(std::string filePath, StaggeredMode mode);
   // print information about Cartesian mesh
   PetscErrorCode printInfo();
 

--- a/src/utilities/SimulationParameters.cpp
+++ b/src/utilities/SimulationParameters.cpp
@@ -60,6 +60,15 @@ void SimulationParameters::initialize(std::string filePath)
   nsave = node["nsave"].as<PetscInt>(nt);
   
   outputFormat = node["outputFormat"].as<std::string>("binary");
+#ifndef PETSC_HAVE_HDF5
+  if (outputFormat == "hdf5")
+  {
+    PetscPrintf(PETSC_COMM_WORLD,
+                "\nERROR: PETSc has not been built with HDF5 available; "
+                "you cannot use `outputFormat: hdf5`\n");
+    exit(1);
+  }
+#endif
   outputFlux = (node["outputFlux"].as<bool>(true)) ? PETSC_TRUE : PETSC_FALSE;
   outputVelocity = (node["outputVelocity"].as<bool>(false)) ? PETSC_TRUE : PETSC_FALSE;
 

--- a/src/utilities/SimulationParameters.cpp
+++ b/src/utilities/SimulationParameters.cpp
@@ -58,6 +58,7 @@ void SimulationParameters::initialize(std::string filePath)
   startStep = node["startStep"].as<PetscInt>(0);
   nt = node["nt"].as<PetscInt>();
   nsave = node["nsave"].as<PetscInt>(nt);
+  fileFormat = node["fileFormat"].as<std::string>("binary");
 
   ibm = stringToIBMethod(node["ibm"].as<std::string>("NONE"));
 
@@ -141,6 +142,7 @@ PetscErrorCode SimulationParameters::printInfo()
   ierr = PetscPrintf(PETSC_COMM_WORLD, "starting time-step: %d\n", startStep); CHKERRQ(ierr);
   ierr = PetscPrintf(PETSC_COMM_WORLD, "number of time-steps: %d\n", nt); CHKERRQ(ierr);
   ierr = PetscPrintf(PETSC_COMM_WORLD, "saving-interval: %d\n", nsave); CHKERRQ(ierr);
+  ierr = PetscPrintf(PETSC_COMM_WORLD, "file format: %s\n", fileFormat.c_str()); CHKERRQ(ierr);
   ierr = PetscPrintf(PETSC_COMM_WORLD, "---------------------------------------\n"); CHKERRQ(ierr);
 
   return 0;

--- a/src/utilities/SimulationParameters.cpp
+++ b/src/utilities/SimulationParameters.cpp
@@ -59,7 +59,7 @@ void SimulationParameters::initialize(std::string filePath)
   nt = node["nt"].as<PetscInt>();
   nsave = node["nsave"].as<PetscInt>(nt);
   
-  fileFormat = node["fileFormat"].as<std::string>("binary");
+  outputFormat = node["outputFormat"].as<std::string>("binary");
   outputFlux = (node["outputFlux"].as<bool>(true)) ? PETSC_TRUE : PETSC_FALSE;
   outputVelocity = (node["outputVelocity"].as<bool>(false)) ? PETSC_TRUE : PETSC_FALSE;
 
@@ -145,7 +145,7 @@ PetscErrorCode SimulationParameters::printInfo()
   ierr = PetscPrintf(PETSC_COMM_WORLD, "starting time-step: %d\n", startStep); CHKERRQ(ierr);
   ierr = PetscPrintf(PETSC_COMM_WORLD, "number of time-steps: %d\n", nt); CHKERRQ(ierr);
   ierr = PetscPrintf(PETSC_COMM_WORLD, "saving-interval: %d\n", nsave); CHKERRQ(ierr);
-  ierr = PetscPrintf(PETSC_COMM_WORLD, "file format: %s\n", fileFormat.c_str()); CHKERRQ(ierr);
+  ierr = PetscPrintf(PETSC_COMM_WORLD, "output format: %s\n", outputFormat.c_str()); CHKERRQ(ierr);
   ierr = PetscPrintf(PETSC_COMM_WORLD, "output flux: %D\n", outputFlux); CHKERRQ(ierr);
   ierr = PetscPrintf(PETSC_COMM_WORLD, "output velocity: %D\n", outputVelocity); CHKERRQ(ierr);
   ierr = PetscPrintf(PETSC_COMM_WORLD, "---------------------------------------\n"); CHKERRQ(ierr);

--- a/src/utilities/SimulationParameters.cpp
+++ b/src/utilities/SimulationParameters.cpp
@@ -66,6 +66,7 @@ void SimulationParameters::initialize(std::string filePath)
     PetscPrintf(PETSC_COMM_WORLD,
                 "\nERROR: PETSc has not been built with HDF5 available; "
                 "you cannot use `outputFormat: hdf5`\n");
+    MPI_Barrier(PETSC_COMM_WORLD);
     exit(1);
   }
 #endif

--- a/src/utilities/SimulationParameters.cpp
+++ b/src/utilities/SimulationParameters.cpp
@@ -58,7 +58,10 @@ void SimulationParameters::initialize(std::string filePath)
   startStep = node["startStep"].as<PetscInt>(0);
   nt = node["nt"].as<PetscInt>();
   nsave = node["nsave"].as<PetscInt>(nt);
+  
   fileFormat = node["fileFormat"].as<std::string>("binary");
+  outputFlux = (node["outputFlux"].as<bool>(true)) ? PETSC_TRUE : PETSC_FALSE;
+  outputVelocity = (node["outputVelocity"].as<bool>(false)) ? PETSC_TRUE : PETSC_FALSE;
 
   ibm = stringToIBMethod(node["ibm"].as<std::string>("NONE"));
 
@@ -143,6 +146,8 @@ PetscErrorCode SimulationParameters::printInfo()
   ierr = PetscPrintf(PETSC_COMM_WORLD, "number of time-steps: %d\n", nt); CHKERRQ(ierr);
   ierr = PetscPrintf(PETSC_COMM_WORLD, "saving-interval: %d\n", nsave); CHKERRQ(ierr);
   ierr = PetscPrintf(PETSC_COMM_WORLD, "file format: %s\n", fileFormat.c_str()); CHKERRQ(ierr);
+  ierr = PetscPrintf(PETSC_COMM_WORLD, "output flux: %D\n", outputFlux); CHKERRQ(ierr);
+  ierr = PetscPrintf(PETSC_COMM_WORLD, "output velocity: %D\n", outputVelocity); CHKERRQ(ierr);
   ierr = PetscPrintf(PETSC_COMM_WORLD, "---------------------------------------\n"); CHKERRQ(ierr);
 
   return 0;

--- a/src/utilities/SimulationParameters.h
+++ b/src/utilities/SimulationParameters.h
@@ -43,7 +43,7 @@ public:
            nt,        ///< number of time steps
            nsave;     ///< data-saving interval
   
-  std::string fileFormat;  ///< output format to use
+  std::string outputFormat;  ///< output format to use
   PetscBool outputFlux,     ///< boolean to output the flux components
             outputVelocity; ///< boolean to output the velocity components
 

--- a/src/utilities/SimulationParameters.h
+++ b/src/utilities/SimulationParameters.h
@@ -44,6 +44,8 @@ public:
            nsave;     ///< data-saving interval
   
   std::string fileFormat;  ///< output format to use
+  PetscBool outputFlux,     ///< boolean to output the flux components
+            outputVelocity; ///< boolean to output the velocity components
 
   IBMethod ibm; ///< type of system to be solved
   

--- a/src/utilities/SimulationParameters.h
+++ b/src/utilities/SimulationParameters.h
@@ -43,6 +43,8 @@ public:
            nt,        ///< number of time steps
            nsave;     ///< data-saving interval
   
+  std::string fileFormat;  ///< output format to use
+
   IBMethod ibm; ///< type of system to be solved
   
   TimeIntegration convection, ///< time-scheme for the convection term

--- a/src/utilities/types.h
+++ b/src/utilities/types.h
@@ -86,6 +86,18 @@ enum IBMethod
 IBMethod stringToIBMethod(std::string s);
 std::string stringFromIBMethod(IBMethod method);
 
+
+/**
+ * \brief Staggered mode to define the location of mesh points.
+ */
+enum StaggeredMode
+{
+  STAGGERED_MODE_X,  ///< x-component of staggered quantity
+  STAGGERED_MODE_Y,  ///< y-component of staggered quantity
+  STAGGERED_MODE_Z,  ///< z-component of staggered quantity
+  CELL_CENTERED      ///< cell-centered quantity
+};
+
 #endif
 
 /**


### PR DESCRIPTION
With this pull-request, I add the possibility for the user to output the numerical solution in HDF5 format.

Previous to this PR, the numerical solution was saved into binary format and we had to develop Python scripts to post-process the simulation; this was enough for 2D simulations but, for future 3D runs, it will be easier to save the solution in HDF5.
HDF5 files are readable by visualization software such as VisIt and ParaView.

To implement this feature, I have been working with g++-5.4.0, PETSc-3.7.4, and HDF5-1.8.12.
The HDF5 package was downloaded and built using the command-line flag `--download-hdf5` when configuring PETSc.

To switch on HDF5 output in PetIBM, the user has to set the line `outputFormat: hdf5` in the input file `simulationParameters.yaml`.
The default value for this options is `binary`.

When we set `outputFormat` to `hdf5`, PetIBM will also write the following grid files into HDF5 format:
- `grids/cell-centered.h5` (stations along gridlines where a cell-centered quantity is defined, such as the pressure);
- `grids/staggered-x.h5` (stations along gridlines where the x-component of a staggered vector field is defined, such as the x-flux);
- `grids/staggered-y.h5` (stations along gridlines where the y-component of a staggered vector field is defined, such as the y-flux);
- `grids/staggered-z.h5` (for 3D runs, stations along gridlines where the z-component of a staggered vector field is defined, such as the z-flux);

Note that the file `grid.txt` is still written in ASCII format in the simulation folder.

In addition, I added the possibility to choose which flow variables to output into files (flux and/or velocity; the lambda variable is always written).
To mention which one(s) to output, the user has to set the lines `outputFlux: true` and/or `outputVelocity: true` in the input file `simulationParameters.yaml`.
The default behavior is to write the flux variables and not the velocity components.

The documentation (`doc` folder) has been updated accordingly.

Overall, the default behavior of the code does not change from before.

I also wrote a Python script `createXMFFile.py` (located in the subdirectory `scripts/python`) that generates a `.xmf` file with a XML schema in it to tell VisIt how to read the HDF5 data.
To print the command-line arguments for this script, use `python $PETIBM_DIR/scripts/python createXMFFile.py --help`.

For information, here is the workflow I used to plot the 2D vorticity field around a cylinder with Visit-2.10.2:
- create a file `times.txt` that maps the time-step index to the time-unit (indices in the first column, time values in the second one),
- generate `phi.xmf` for the cell-centered variable `phi`:
```
python $PETIBM_DIR/scripts/python/createXMFFile.py \
    --grid-file grids/cell-centered.h5 \
    --grid-size 186 186 \
    --variables phi \
    --times-file times.txt \
    --outfile phi.xmf
```
- generate `ux.xmf` for the x-component `ux` of the staggered velocity:
```
python $PETIBM_DIR/scripts/python/createXMFFile.py \
    --grid-file grids/staggered-x.h5 \
    --grid-size 185 186 \
    --variables ux \
    --times-file times.txt \
    --outfile ux.xmf
```
- generate `uy.xmf` for the y-component `uy` of the staggered velocity:
```
python $PETIBM_DIR/scripts/python/createXMFFile.py \
    --grid-file grids/staggered-y.h5 \
    --grid-size 186 185 \
    --variables uy \
    --times-file times.txt \
    --outfile uy.xmf
```
- launch VisIt and load the file `phi.xmf` (`phi` is defined at cell-centers and we are going to use its grid to compute the vorticity field)
- go to `Controls->Expressions...` and create the `vort` variable using the expression:
```
curl({pos_cmfe(<ux.xmf[0]id:ux>, Grid, 1.0),
      pos_cmfe(<uy.xmf[0]id:uy>, Grid, 0.0)})
```
(This expression says: project the velocity components on the `Grid` where `phi` and compute the curl. The third parameters of the function `pos_cmfe()` is the value at the boundary used to interpolate.)
- draw a `PseudoColor` plot of the newly created variable `vort`

For a 3D problem, I used the following expression in VisIt to compute the spanwise vorticity:
```
dot(
curl({pos_cmfe(<ux.xmf[0]id:ux>, Grid, 1.0),
      pos_cmfe(<uy.xmf[0]id:uy>, Grid, 0.0),
      pos_cmfe(<uz.xmf[0]id:uz>, Grid, 0.0)}),
{0, 0, 1})
```

Suggestions and feedback are welcome.