### PR TITLE
Fix function calls for generating VTK files

### DIFF
--- a/scripts/python/generateVTKFiles.py
+++ b/scripts/python/generateVTKFiles.py
@@ -119,25 +119,23 @@ def main(args):
   print('[variables] {}'.format(args.variables))
 
   # list of time-steps to post-process
-  time_steps = ioPetIBM.get_time_steps(args.directory, args.time_steps)
+  time_steps = ioPetIBM.get_time_steps(args.time_steps, args.directory)
 
   # read mesh grid
   grid = ioPetIBM.read_grid(args.directory)
 
   for time_step in time_steps:
     if 'velocity' in args.variables:
-      velocity = ioPetIBM.read_velocity(args.directory, time_step, grid,
-                                        periodic=args.periodic)
+      velocity = ioPetIBM.read_velocity(
+          time_step, grid, args.periodic, args.directory)
       # need to get velocity at cell-centers, not staggered arrangement
       velocity = interpolate_cell_centers(velocity)
-      ioPetIBM.write_vtk(velocity, args.directory, time_step,
-                         name='velocity',
+      ioPetIBM.write_vtk(velocity, time_step, 'velocity', args.directory,
                          view=[args.bottom_left, args.top_right],
                          stride=args.stride)
     if 'pressure' in args.variables:
-      pressure = ioPetIBM.read_pressure(args.directory, time_step, grid)
-      ioPetIBM.write_vtk(pressure, args.directory, time_step,
-                         name='pressure',
+      pressure = ioPetIBM.read_pressure(time_step, grid, args.directory)
+      ioPetIBM.write_vtk(pressure, time_step, 'pressure', args.directory,
                          view=[args.bottom_left, args.top_right],
                          stride=args.stride)
 

--- a/scripts/python/ioPetIBM.py
+++ b/scripts/python/ioPetIBM.py
@@ -289,7 +289,7 @@ def write_vtk(field, time_step, name,
     print('Make directory: {}'.format(vtk_directory))
     os.makedirs(vtk_directory)
   vtk_file_path = os.path.join(vtk_directory,
-                               name + '{:0>7}'.format(time_step))
+                               name + '{:0>7}.vtk'.format(time_step))
   # get coordinates within the view
   x = field[0].x[mx]
   y = field[0].y[my]


### PR DESCRIPTION
- fix the extension of ouput vtk files, i.e., append .vtk to the files
- fix the orders of arguments in function calls to ioPetIBM.py in
  generateVTKFiles.py