### PR TITLE
Feature split poisson pc

### DIFF
--- a/src/solvers/navierStokes/inline/createSolvers.inl
+++ b/src/solvers/navierStokes/inline/createSolvers.inl
@@ -47,7 +47,7 @@ PetscErrorCode NavierStokesSolver<dim>::createSolvers()
                          "\nERROR: vSolveType should be either 'CPU' or 'GPU'.\n");
       exit(1);
   }
-  velocity->create(A);
+  velocity->create(A, qPack);
 
   // possibility to overwrite the path of the configuration file
   // using the command-line parameter: `-poisson_config_file <file-path>`
@@ -75,7 +75,7 @@ PetscErrorCode NavierStokesSolver<dim>::createSolvers()
                          "\nERROR: pSolveType should be either 'CPU' or 'GPU'.\n");
       exit(1);
   }
-  poisson->create(QTBNQ);
+  poisson->create(QTBNQ, lambdaPack, PETSC_TRUE);
 
   return 0;
 } // createSolvers

--- a/src/utilities/solvers/amgxsolver.cpp
+++ b/src/utilities/solvers/amgxsolver.cpp
@@ -8,7 +8,8 @@
 /*!
  * \brief Creates the AmgX solver.
  */
-PetscErrorCode AMGXSolver::create(const Mat &A)
+PetscErrorCode AMGXSolver::create(
+        const Mat &A, const DM &daPack, const PetscBool &split)
 {
   PetscErrorCode ierr;
 

--- a/src/utilities/solvers/amgxsolver.h
+++ b/src/utilities/solvers/amgxsolver.h
@@ -23,7 +23,8 @@ public:
     amgx.finalize();
   };
 
-  PetscErrorCode create(const Mat &A);
+  PetscErrorCode create(const Mat &A, const DM &daPack, 
+          const PetscBool &split=PETSC_FALSE);
   PetscErrorCode solve(Vec &x, Vec &b);
   PetscErrorCode getIters(PetscInt &iters);
 

--- a/src/utilities/solvers/kspsolver.cpp
+++ b/src/utilities/solvers/kspsolver.cpp
@@ -43,7 +43,7 @@ PetscErrorCode KSPSolver::create(
       {
           ierr = PetscPrintf(PETSC_COMM_WORLD, "%s\n", type); CHKERRQ(ierr);
           ierr = PetscPrintf(PETSC_COMM_WORLD, "%s\n", DMCOMPOSITE); CHKERRQ(ierr);
-          SETERRQ(PETSC_COMM_WORLD, 56, "Predicitioner is set to be splited, "
+          SETERRQ(PETSC_COMM_WORLD, 56, "Preconditioner is set to be split, "
                   "but the DM passed in is not a DMComposite!");
       }
   }

--- a/src/utilities/solvers/kspsolver.cpp
+++ b/src/utilities/solvers/kspsolver.cpp
@@ -2,13 +2,16 @@
  * \file kspsolver.cpp
  */
 
+# include <cstring>
+
 #include "kspsolver.h"
 
 
 /*!
  * \brief Creates the KSP solver.
  */
-PetscErrorCode KSPSolver::create(const Mat &A)
+PetscErrorCode KSPSolver::create(
+        const Mat &A, const DM &daPack, const PetscBool &split)
 {
   PetscErrorCode ierr;
 
@@ -22,10 +25,79 @@ PetscErrorCode KSPSolver::create(const Mat &A)
   ierr = KSPSetInitialGuessNonzero(ksp, PETSC_TRUE); CHKERRQ(ierr);
   ierr = KSPSetType(ksp, KSPCG); CHKERRQ(ierr);
   ierr = KSPSetReusePreconditioner(ksp, PETSC_TRUE); CHKERRQ(ierr);
+  ierr = KSPSetNormType(ksp, KSP_NORM_UNPRECONDITIONED); CHKERRQ(ierr);
+
+
+  DMType    type;
+  ierr = DMGetType(daPack, &type); CHKERRQ(ierr);
+
+  if (split)
+  {
+      if (std::strcmp(type, DMCOMPOSITE) == 0)
+      {
+          PetscInt  numDM;
+          ierr = DMCompositeGetNumberDM(daPack, &numDM); CHKERRQ(ierr);
+
+          ierr = setSplitPC(numDM, daPack); CHKERRQ(ierr);
+      }
+      else
+      {
+          ierr = PetscPrintf(PETSC_COMM_WORLD, "%s\n", type); CHKERRQ(ierr);
+          ierr = PetscPrintf(PETSC_COMM_WORLD, "%s\n", DMCOMPOSITE); CHKERRQ(ierr);
+          SETERRQ(PETSC_COMM_WORLD, 56, "Predicitioner is set to be splited, "
+                  "but the DM passed in is not a DMComposite!");
+      }
+  }
+
   ierr = KSPSetFromOptions(ksp); CHKERRQ(ierr);
+  ierr = KSPSetUp(ksp);
+  ierr = KSPView(ksp, PETSC_VIEWER_STDOUT_WORLD); CHKERRQ(ierr);
 
   return 0;
 } // create
+
+
+PetscErrorCode KSPSolver::setSplitPC(const PetscInt &numDM, const DM &daPack)
+{
+    PetscFunctionBeginUser;
+
+    PetscErrorCode      ierr;
+
+    IS      *is;
+    ierr = DMCompositeGetGlobalISs(daPack, &is); CHKERRQ(ierr);
+
+    PC      pc;
+    ierr = KSPGetPC(ksp, &pc); CHKERRQ(ierr);
+    ierr = PCSetType(pc, PCFIELDSPLIT); CHKERRQ(ierr);
+    ierr = PCFieldSplitSetType(pc, PC_COMPOSITE_ADDITIVE); CHKERRQ(ierr);
+
+    for(int i=0; i<numDM; ++i)
+    {
+        ierr = PCFieldSplitSetIS(pc, nullptr, is[i]); CHKERRQ(ierr);
+    }
+
+
+    KSP     *childKsp;
+    ierr = PCFieldSplitGetSubKSP(pc, nullptr, &childKsp); CHKERRQ(ierr);
+
+    DM      *dms = new DM[numDM];
+    ierr = DMCompositeGetEntriesArray(daPack, dms); CHKERRQ(ierr);
+
+    for(int i=0; i<numDM; ++i)
+    {
+        ierr = KSPSetType(childKsp[i], KSPBCGS); CHKERRQ(ierr);
+        ierr = KSPSetDM(childKsp[i], dms[i]); CHKERRQ(ierr);
+        ierr = KSPSetDMActive(childKsp[i], PETSC_FALSE); CHKERRQ(ierr);
+        ierr = KSPSetInitialGuessNonzero(childKsp[i], PETSC_TRUE); CHKERRQ(ierr);
+        ierr = KSPSetReusePreconditioner(childKsp[i], PETSC_TRUE); CHKERRQ(ierr);
+
+        PC  pcField;
+        ierr = KSPGetPC(childKsp[i], &pcField); CHKERRQ(ierr);
+        ierr = PCSetType(pcField, PCBJACOBI); CHKERRQ(ierr);
+    }
+
+    PetscFunctionReturn(0);
+}
 
 
 /*!

--- a/src/utilities/solvers/kspsolver.cpp
+++ b/src/utilities/solvers/kspsolver.cpp
@@ -25,7 +25,6 @@ PetscErrorCode KSPSolver::create(
   ierr = KSPSetInitialGuessNonzero(ksp, PETSC_TRUE); CHKERRQ(ierr);
   ierr = KSPSetType(ksp, KSPCG); CHKERRQ(ierr);
   ierr = KSPSetReusePreconditioner(ksp, PETSC_TRUE); CHKERRQ(ierr);
-  ierr = KSPSetNormType(ksp, KSP_NORM_UNPRECONDITIONED); CHKERRQ(ierr);
 
 
   DMType    type;

--- a/src/utilities/solvers/kspsolver.cpp
+++ b/src/utilities/solvers/kspsolver.cpp
@@ -87,7 +87,6 @@ PetscErrorCode KSPSolver::setSplitPC(const PetscInt &numDM, const DM &daPack)
         ierr = KSPSetType(childKsp[i], KSPBCGS); CHKERRQ(ierr);
         ierr = KSPSetDM(childKsp[i], dms[i]); CHKERRQ(ierr);
         ierr = KSPSetDMActive(childKsp[i], PETSC_FALSE); CHKERRQ(ierr);
-        ierr = KSPSetInitialGuessNonzero(childKsp[i], PETSC_TRUE); CHKERRQ(ierr);
         ierr = KSPSetReusePreconditioner(childKsp[i], PETSC_TRUE); CHKERRQ(ierr);
 
         PC  pcField;

--- a/src/utilities/solvers/kspsolver.h
+++ b/src/utilities/solvers/kspsolver.h
@@ -24,7 +24,8 @@ public:
     KSPDestroy(&ksp);
   };
 
-  PetscErrorCode create(const Mat &A);
+  PetscErrorCode create(const Mat &A, const DM &daPack, 
+          const PetscBool &split=PETSC_FALSE);
   PetscErrorCode solve(Vec &x, Vec &b);
   PetscErrorCode getIters(PetscInt &iters);
 
@@ -32,6 +33,8 @@ private:
   KSP ksp;
   std::string prefix;
   std::string options;
+
+  PetscErrorCode setSplitPC(const PetscInt &numDM, const DM &daPack);
 
 
 }; // KSPSolver

--- a/src/utilities/solvers/solver.h
+++ b/src/utilities/solvers/solver.h
@@ -16,7 +16,8 @@ class Solver
 {
 public:
   virtual ~Solver(){ }
-  virtual PetscErrorCode create(const Mat &A) = 0;
+  virtual PetscErrorCode create(const Mat &A, const DM &daPack, 
+          const PetscBool &split=PETSC_FALSE) = 0;
   virtual PetscErrorCode solve(Vec &x, Vec &b) = 0;
   virtual PetscErrorCode getIters(PetscInt &iters) = 0;
 


### PR DESCRIPTION
With this feature, now users can set different preconditioners for modified Poisson system through PETSc cmd. 

With setting `-poisson_pc_type` to types other than `fieldsplit`, the behavior is the same as old code (for example, `-poisson_pc_type gamg`).

Without setting `-poisson_pc_type` from cmd (or with `-poisson_pc_type fieldsplit`), the behavior is using multiplicative decomposition, and using block jacobi preconditioners for both (G^T)(B_n)G and E(B_n)(E^T) sub-matrices. Users can change to other kinds of decomposition method using `-poisson_pc_fieldsplit_type XXXXX`. To set the sub KSP and PC for each sub-matrix, add prefix `-poisson_fieldsplit_${index}_` to the sub KSP and PC settings. `${index}` should follow the order of how DMs are added to `lambdaPack` in PetIBM source code. For example, in current PetIBM, `${index}=0` means the pressure field, which is represented by the sub-matrix (G^T)(B_n)G, while `${index}=1` means the body force field, which is represented by sub-matrix E(B_n)(E^T). In the future, if each body is built with one DMDA, then there will be more `${index}`.

For more details, please consult PETSc Manual, chapter 4.5.

Here is an example of the setting:

```
-poisson_ksp_monitor
-poisson_ksp_type gmres
-poisson_ksp_gmres_restart 100
-poisson_ksp_rtol 1.0E-05
-poisson_ksp_atol 1.0E-50
-poisson_ksp_max_it 20000

-poisson_pc_fieldsplit_type additive

-poisson_fieldsplit_0_ksp_type cg
-poisson_fieldsplit_0_ksp_initial_guess_nonzero 1
-poisson_fieldsplit_0_ksp_rtol 1.0E-06
-poisson_fieldsplit_0_ksp_atol 1.0E-50
-poisson_fieldsplit_0_pc_type hypre
-poisson_fieldsplit_0_pc_hypre_type boomeramg
-poisson_fieldsplit_0_pc_hypre_boomeramg_cycle_type V
-poisson_fieldsplit_0_pc_hypre_boomeramg_max_levels 100
-poisson_fieldsplit_0_pc_hypre_boomeramg_max_iter 1
-poisson_fieldsplit_0_pc_hypre_boomeramg_tol 0.0
-poisson_fieldsplit_0_pc_hypre_boomeramg_truncfactor 0.0
-poisson_fieldsplit_0_pc_hypre_boomeramg_P_max 0
-poisson_fieldsplit_0_pc_hypre_boomeramg_agg_nl 0
-poisson_fieldsplit_0_pc_hypre_boomeramg_agg_num_paths 1
-poisson_fieldsplit_0_pc_hypre_boomeramg_strong_threshold 0.25
-poisson_fieldsplit_0_pc_hypre_boomeramg_max_row_sum 1.0
-poisson_fieldsplit_0_pc_hypre_boomeramg_grid_sweeps_down 1
-poisson_fieldsplit_0_pc_hypre_boomeramg_grid_sweeps_up 1
-poisson_fieldsplit_0_pc_hypre_boomeramg_grid_sweeps_coarse 1
-poisson_fieldsplit_0_pc_hypre_boomeramg_relax_type_all symmetric-SOR/Jacobi
-poisson_fieldsplit_0_pc_hypre_boomeramg_relax_type_coarse symmetric-SOR/Jacobi
-poisson_fieldsplit_0_pc_hypre_boomeramg_relax_weight_all 0.8
-poisson_fieldsplit_0_pc_hypre_boomeramg_outer_relax_weight_all 1.0
-poisson_fieldsplit_0_pc_hypre_boomeramg_measure_type local
-poisson_fieldsplit_0_pc_hypre_boomeramg_coarsen_type HMIS
-poisson_fieldsplit_0_pc_hypre_boomeramg_interp_type ext+i-cc

-poisson_fieldsplit_1_ksp_type preonly
-poisson_fieldsplit_1_pc_type lu
-poisson_fieldsplit_1_pc_factor_mat_solver_package superlu_dist
```

In this example, the whole modified Poisson system is solved by GMRES with split preconditioners. The domain decomposition method used in splitting is the additive method. For the pressure field, the solver is CG, while the preconditioner is classical AMG from Hypre package. And for the forece field, we use direct solver provided by SuperLU_dist.