### PR TITLE
Pin pressure at one point when using AmgX solver

### DIFF
--- a/src/solvers/navierStokes/NavierStokesSolver.cpp
+++ b/src/solvers/navierStokes/NavierStokesSolver.cpp
@@ -126,7 +126,6 @@ PetscErrorCode NavierStokesSolver<dim>::initializeCommon()
   ierr = generateA(); CHKERRQ(ierr);
   ierr = generateBNQ(); CHKERRQ(ierr);
   ierr = generateQTBNQ(); CHKERRQ(ierr);
-  ierr = setNullSpace(); CHKERRQ(ierr);
   ierr = createSolvers(); CHKERRQ(ierr);
 
   if (parameters->startStep > 0 || flow->initialCustomField)
@@ -245,9 +244,18 @@ PetscErrorCode NavierStokesSolver<dim>::assembleRHSPoisson()
   ierr = generateR2(); CHKERRQ(ierr);
   ierr = VecScale(r2, -1.0); CHKERRQ(ierr);
   ierr = MatMultAdd(QT, qStar, r2, rhs2); CHKERRQ(ierr);
+
+#ifdef HAVE_AMGX
+  // Set the value of the bottom-left corner pressure point to be zero
+  // to deal with the null space when using AmgX solver
+  ierr = VecSetValue(rhs2, 0, 0.0, INSERT_VALUES); CHKERRQ(ierr);
+  ierr = VecAssemblyBegin(rhs2); CHKERRQ(ierr);
+  ierr = VecAssemblyEnd(rhs2); CHKERRQ(ierr);
+#endif
+
   ierr = PetscObjectViewFromOptions((PetscObject) rhs2, NULL, "-rhs2_vec_view"); CHKERRQ(ierr);
   
-  ierr = PetscLogStagePop(); CHKERRQ(ierr);  
+  ierr = PetscLogStagePop(); CHKERRQ(ierr);
 
   return 0;
 } // assembleRHSPoisson


### PR DESCRIPTION
The Poisson matrix (with Neumann boundary conditions) is singular;
its possesses a non-trivial null space (that consists in the space of
constant functions).

When using Krylov solvers from PETSc, we attach the null space to the Poisson
matrix (or its modified version when there is an immersed boundary).
The null space is then removed by the PETSc linear solvers.
This means, when using AmgX as a solver, we do not need to create a
`MatNullSpace` object.
Therefore, the method `setNullSpace` is now called only if using PETSc KSPs.

With AmgX, without removing the null space, the pressure if computed up to a
constant which can vary from one time-step to another.
For example, the farfield pressure for the 2D flow around a cylinder (Re=40)
will change over the course of the simulation.
A workaround is to pin the pressure at one point in the farfield domain.
Currently, the pressure point at the front-bottom-left corner is set to the
value zero.
To do this, we remove all off-diagonal elements in the first row of the
Poisson matrix, while the diagonal element is set to one.
Then, we set the first element of the right-hand side vector to be zero.

Note that, when using AmgX solver, the Poisson matrix is not symmetric anymore.