### PR TITLE
Improvements in factorization branch

### DIFF
--- a/applications/decoupledibpm/decoupledibpm.cpp
+++ b/applications/decoupledibpm/decoupledibpm.cpp
@@ -396,38 +396,28 @@ PetscErrorCode DecoupledIBPMSolver::writeIterations(
     PetscErrorCode ierr;
     PetscInt nIters;
     PetscReal res;
-    PetscViewer viewer;
-    static PetscFileMode mode = FILE_MODE_WRITE;
 
     PetscFunctionBeginUser;
     
-    // create ASCII viewer
-    ierr = PetscViewerCreate(PETSC_COMM_WORLD, &viewer); CHKERRQ(ierr);
-    ierr = PetscViewerSetType(viewer, PETSCVIEWERASCII); CHKERRQ(ierr);
-    ierr = PetscViewerFileSetMode(viewer, mode); CHKERRQ(ierr);
-    ierr = PetscViewerFileSetName(viewer, filePath.c_str()); CHKERRQ(ierr);
-    
     // write current time
-    ierr = PetscViewerASCIIPrintf(viewer, "%d", timeIndex); CHKERRQ(ierr);
+    ierr = PetscViewerASCIIPrintf(
+            asciiViewers[filePath], "%d", timeIndex); CHKERRQ(ierr);
     
     ierr = vSolver->getIters(nIters); CHKERRQ(ierr);
     ierr = vSolver->getResidual(res); CHKERRQ(ierr);
-    ierr = PetscViewerASCIIPrintf(viewer, "\t%d\t%e", nIters, res); CHKERRQ(ierr);
+    ierr = PetscViewerASCIIPrintf(
+            asciiViewers[filePath], "\t%d\t%e", nIters, res); CHKERRQ(ierr);
     
     ierr = pSolver->getIters(nIters); CHKERRQ(ierr);
     ierr = pSolver->getResidual(res); CHKERRQ(ierr);
-    ierr = PetscViewerASCIIPrintf(viewer, "\t%d\t%e", nIters, res); CHKERRQ(ierr);
+    ierr = PetscViewerASCIIPrintf(
+            asciiViewers[filePath], "\t%d\t%e", nIters, res); CHKERRQ(ierr);
     
     ierr = fSolver->getIters(nIters); CHKERRQ(ierr);
     ierr = fSolver->getResidual(res); CHKERRQ(ierr);
-    ierr = PetscViewerASCIIPrintf(viewer, "\t%d\t%e\n", nIters, res); CHKERRQ(ierr);
+    ierr = PetscViewerASCIIPrintf(
+            asciiViewers[filePath], "\t%d\t%e\n", nIters, res); CHKERRQ(ierr);
     
-    // destroy
-    ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
-    
-    // next time we'll append data
-    mode = FILE_MODE_APPEND;
-
     PetscFunctionReturn(0);
 } // writeIterations
 
@@ -437,9 +427,7 @@ PetscErrorCode DecoupledIBPMSolver::writeIntegratedForces(
             const PetscReal &t, const std::string &filePath)
 {
     PetscErrorCode ierr;
-    PetscViewer         viewer;
     petibm::type::RealVec2D     fAvg;
-    static PetscFileMode mode = FILE_MODE_WRITE;
 
     PetscFunctionBeginUser;
 
@@ -450,14 +438,9 @@ PetscErrorCode DecoupledIBPMSolver::writeIntegratedForces(
 
     ierr = PetscLogStagePop(); CHKERRQ(ierr);
     
-    // create ASCII viewer
-    ierr = PetscViewerCreate(PETSC_COMM_WORLD, &viewer); CHKERRQ(ierr);
-    ierr = PetscViewerSetType(viewer, PETSCVIEWERASCII); CHKERRQ(ierr);
-    ierr = PetscViewerFileSetMode(viewer, mode); CHKERRQ(ierr);
-    ierr = PetscViewerFileSetName(viewer, filePath.c_str()); CHKERRQ(ierr);
-    
     // write current time
-    ierr = PetscViewerASCIIPrintf(viewer, "%10.8e", t); CHKERRQ(ierr);
+    ierr = PetscViewerASCIIPrintf(
+            asciiViewers[filePath], "%10.8e", t); CHKERRQ(ierr);
     
     // write forces body by body
     for(unsigned int i=0; i<bodies->nBodies; ++i)
@@ -465,16 +448,10 @@ PetscErrorCode DecoupledIBPMSolver::writeIntegratedForces(
         for(unsigned int d=0; d<mesh->dim; ++d)
         {
             ierr = PetscViewerASCIIPrintf(
-                    viewer, "\t%10.8e", fAvg[i][d]); CHKERRQ(ierr);
+                    asciiViewers[filePath], "\t%10.8e", fAvg[i][d]); CHKERRQ(ierr);
         }
     }
-    ierr = PetscViewerASCIIPrintf(viewer, "\n"); CHKERRQ(ierr);
+    ierr = PetscViewerASCIIPrintf(asciiViewers[filePath], "\n"); CHKERRQ(ierr);
     
-    // destroy
-    ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
-    
-    // next we'll just append data
-    mode = FILE_MODE_APPEND;
-
     PetscFunctionReturn(0);
 } // writeIntegratedForces

--- a/applications/decoupledibpm/decoupledibpm.cpp
+++ b/applications/decoupledibpm/decoupledibpm.cpp
@@ -20,6 +20,51 @@ DecoupledIBPMSolver::DecoupledIBPMSolver(
 } // DecoupledIBPMSolver
 
 
+DecoupledIBPMSolver::~DecoupledIBPMSolver()
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode ierr;
+    PetscBool finalized;
+
+    ierr = PetscFinalized(&finalized); CHKERRV(ierr);
+    if (finalized) return;
+
+    ierr = VecDestroy(&df); CHKERRV(ierr);
+    ierr = VecDestroy(&f); CHKERRV(ierr);
+    ierr = VecDestroy(&Eu); CHKERRV(ierr);
+    
+    ierr = MatDestroy(&H); CHKERRV(ierr);
+    ierr = MatDestroy(&E); CHKERRV(ierr);
+    ierr = MatDestroy(&EBNH); CHKERRV(ierr);
+    ierr = MatDestroy(&BNH); CHKERRV(ierr);
+}
+
+
+// destroy
+PetscErrorCode DecoupledIBPMSolver::destroy()
+{
+    PetscErrorCode ierr;
+
+    PetscFunctionBeginUser;
+    
+    ierr = VecDestroy(&df); CHKERRQ(ierr);
+    ierr = VecDestroy(&f); CHKERRQ(ierr);
+    ierr = VecDestroy(&Eu); CHKERRQ(ierr);
+    
+    ierr = MatDestroy(&H); CHKERRQ(ierr);
+    ierr = MatDestroy(&E); CHKERRQ(ierr);
+    ierr = MatDestroy(&EBNH); CHKERRQ(ierr);
+    ierr = MatDestroy(&BNH); CHKERRQ(ierr);
+    
+    fSolver.reset();
+    bodies.reset();
+    
+    ierr = NavierStokesSolver::destroy(); CHKERRQ(ierr);
+
+    PetscFunctionReturn(0);
+} // finalize
+
+
 PetscErrorCode DecoupledIBPMSolver::initialize(
         const petibm::type::Mesh &inMesh,
         const petibm::type::Boundary &inBC,
@@ -433,28 +478,3 @@ PetscErrorCode DecoupledIBPMSolver::writeIntegratedForces(
 
     PetscFunctionReturn(0);
 } // writeIntegratedForces
-
-
-// finalize
-PetscErrorCode DecoupledIBPMSolver::finalize()
-{
-    PetscErrorCode ierr;
-
-    PetscFunctionBeginUser;
-    
-    fSolver.~shared_ptr();
-    bodies.~shared_ptr();
-    
-    ierr = VecDestroy(&df); CHKERRQ(ierr);
-    ierr = VecDestroy(&f); CHKERRQ(ierr);
-    ierr = VecDestroy(&Eu); CHKERRQ(ierr);
-    
-    ierr = MatDestroy(&H); CHKERRQ(ierr);
-    ierr = MatDestroy(&E); CHKERRQ(ierr);
-    ierr = MatDestroy(&EBNH); CHKERRQ(ierr);
-    ierr = MatDestroy(&BNH); CHKERRQ(ierr);
-    
-    ierr = NavierStokesSolver::finalize(); CHKERRQ(ierr);
-
-    PetscFunctionReturn(0);
-} // finalize

--- a/applications/decoupledibpm/decoupledibpm.h
+++ b/applications/decoupledibpm/decoupledibpm.h
@@ -23,6 +23,7 @@ public:
 
     // public members that don't change
     using NavierStokesSolver::write;
+    using NavierStokesSolver::initializeASCIIFiles;
     
     /** \brief Default constructor. */
     DecoupledIBPMSolver() = default;

--- a/applications/decoupledibpm/decoupledibpm.h
+++ b/applications/decoupledibpm/decoupledibpm.h
@@ -43,7 +43,10 @@ public:
             const YAML::Node &node);
 
     /** \brief Default destructor. */
-    ~DecoupledIBPMSolver() = default;
+    ~DecoupledIBPMSolver();
+
+    /** \brief manually destroy data. */
+    PetscErrorCode destroy();
 
     /** \brief Initialize vectors, operators, and linear solvers. */
     PetscErrorCode initialize(
@@ -90,9 +93,6 @@ public:
      */
     PetscErrorCode writeIntegratedForces(
             const PetscReal &t, const std::string &filePath);
-
-    /** \brief Destroy PETSc objects (vectors and matrices) and linear solvers. */
-    PetscErrorCode finalize();
 
 protected:
     

--- a/applications/decoupledibpm/main.cpp
+++ b/applications/decoupledibpm/main.cpp
@@ -70,13 +70,11 @@ int main(int argc, char **argv)
     // current time
     PetscReal t = start * dt;
              
-    // file to log information of linear solvers
-    std::string iterationsFile = 
-        config["directory"].as<std::string>() + "/iterations.txt";
+    // directory where file to log information of linear solvers in
+    std::string iterationsFile = config["directory"].as<std::string>() + "/";
              
-    // file to log averaged Lagrangian forces
-    std::string forceFile = 
-        config["directory"].as<std::string>() + "/forces.txt";
+    // directory where file to log averaged Lagrangian forces in
+    std::string forceFile = config["directory"].as<std::string>() + "/";
     
     
     if (start == 0) // write initial solutions to a HDF5
@@ -91,6 +89,9 @@ int main(int argc, char **argv)
         CHKERRQ(ierr);
         
         ierr = PetscPrintf(PETSC_COMM_WORLD, "done\n"); CHKERRQ(ierr);
+
+        iterationsFile += "iterations.txt";
+        forceFile += "forces.txt";
     }
     else // restart
     {
@@ -104,7 +105,14 @@ int main(int argc, char **argv)
         CHKERRQ(ierr);
         
         ierr = PetscPrintf(PETSC_COMM_WORLD, "done\n"); CHKERRQ(ierr);
+
+        iterationsFile += "iterations-" + std::to_string(start) + ".txt";
+        forceFile += "forces-" + std::to_string(start) + ".txt";
     }
+
+    // initialize the PetscViewers of ASCII files in the solver class
+    ierr = solver.initializeASCIIFiles(iterationsFile); CHKERRQ(ierr);
+    ierr = solver.initializeASCIIFiles(forceFile); CHKERRQ(ierr);
     
     // start time marching
     for (int ite=start+1; ite<=end; ite++)

--- a/applications/navierstokes/main.cpp
+++ b/applications/navierstokes/main.cpp
@@ -60,9 +60,8 @@ int main(int argc, char **argv)
     // number of steps to save solutions
     PetscInt nrestart = config["parameters"]["nrestart"].as<PetscInt>();
              
-    // file to log information of linear solvers
-    std::string iterationsFile = 
-        config["directory"].as<std::string>() + "/iterations.txt";
+    // directory where file to log information of linear solvers in
+    std::string iterationsFile = config["directory"].as<std::string>() + "/";
     
     
     if (start == 0) // write initial solutions to a HDF5
@@ -77,6 +76,9 @@ int main(int argc, char **argv)
         CHKERRQ(ierr);
         
         ierr = PetscPrintf(PETSC_COMM_WORLD, "done\n"); CHKERRQ(ierr);
+
+             
+        iterationsFile += "iterations.txt";
     }
     else // restart
     {
@@ -90,7 +92,12 @@ int main(int argc, char **argv)
         CHKERRQ(ierr);
         
         ierr = PetscPrintf(PETSC_COMM_WORLD, "done\n"); CHKERRQ(ierr);
+
+        iterationsFile += "iterations-" + std::to_string(start) + ".txt";
     }
+
+    // initialize the PetscViewers of ASCII files in the solver class
+    ierr = solver.initializeASCIIFiles(iterationsFile); CHKERRQ(ierr);
     
     // start time marching
     for (int ite=start+1; ite<=end; ite++)

--- a/applications/navierstokes/navierstokes.h
+++ b/applications/navierstokes/navierstokes.h
@@ -44,7 +44,15 @@ public:
     /**
      * \brief Default destructor.
      */
-    ~NavierStokesSolver() = default;
+    ~NavierStokesSolver();
+
+
+    /**
+     * \brief manually destroy data.
+     *
+     * \return PetscErrorCode.
+     */
+    PetscErrorCode destroy();
 
     /**
      * \brief Initialize vectors, operators, and linear solvers.
@@ -93,12 +101,6 @@ public:
     PetscErrorCode writeIterations(
             const int &timeIndex, const std::string &filePath);
 
-    /**
-     * \brief Destroy PETSc objects (vectors and matrices) and linear solvers.
-     */
-    PetscErrorCode finalize();
-
-    
 protected:
     
     

--- a/applications/navierstokes/navierstokes.h
+++ b/applications/navierstokes/navierstokes.h
@@ -92,14 +92,27 @@ public:
     PetscErrorCode readRestartData(const std::string &filePath);
 
     /**
+     * \brief initialize vewers for ASCII files, such as iteration log.
+     *
+     * \param filePath [in] a tring indicating the path to the file.
+     * \param mode [in] either FILE_MODE_WRITE (default) or FILE_MODE_APPEND.
+     *
+     * \return PetscErrorCode.
+     */
+    PetscErrorCode initializeASCIIFiles(const std::string &filePath,
+            const PetscFileMode &mode=FILE_MODE_WRITE);
+
+    /**
      * \brief Write number of iterations executed by each solver at current time
      *        step.
      *
-     * \param timeIndex Time-step index
-     * \param filePath Path of the file to write in
+     * For a given `filePath`, an `initializeASCIIFiles` should be called for 
+     * this `filePath` prior any call to `writeIterations`.
+     *
+     * \param timeIndex [in] Time-step index
+     * \param filePath [in] Path of the file to write in
      */
-    PetscErrorCode writeIterations(
-            const int &timeIndex, const std::string &filePath);
+    PetscErrorCode writeIterations(const int &timeIndex, const std::string &filePath);
 
 protected:
     
@@ -212,6 +225,11 @@ protected:
     
     /** \brief Log write phase. */
     PetscLogStage stageWrite;
+
+
+
+    /** \brief a dictionary mapping file path to PetscViewers. */
+    std::map<std::string, PetscViewer> asciiViewers;
     
 
     

--- a/applications/tairacolonius/main.cpp
+++ b/applications/tairacolonius/main.cpp
@@ -70,13 +70,11 @@ int main(int argc, char **argv)
     // current time
     PetscReal t = start * dt;
              
-    // file to log information of linear solvers
-    std::string iterationsFile = 
-        config["directory"].as<std::string>() + "/iterations.txt";
+    // directory where file to log information of linear solvers in
+    std::string iterationsFile = config["directory"].as<std::string>() + "/";
              
-    // file to log averaged Lagrangian forces
-    std::string forceFile = 
-        config["directory"].as<std::string>() + "/forces.txt";
+    // directory where file to log averaged Lagrangian forces in
+    std::string forceFile = config["directory"].as<std::string>() + "/";
     
     
     if (start == 0) // write initial solutions to a HDF5
@@ -91,6 +89,9 @@ int main(int argc, char **argv)
         CHKERRQ(ierr);
         
         ierr = PetscPrintf(PETSC_COMM_WORLD, "done\n"); CHKERRQ(ierr);
+
+        iterationsFile += "iterations.txt";
+        forceFile += "forces.txt";
     }
     else // restart
     {
@@ -104,7 +105,14 @@ int main(int argc, char **argv)
         CHKERRQ(ierr);
         
         ierr = PetscPrintf(PETSC_COMM_WORLD, "done\n"); CHKERRQ(ierr);
+
+        iterationsFile += "iterations-" + std::to_string(start) + ".txt";
+        forceFile += "forces-" + std::to_string(start) + ".txt";
     }
+
+    // initialize the PetscViewers of ASCII files in the solver class
+    ierr = solver.initializeASCIIFiles(iterationsFile); CHKERRQ(ierr);
+    ierr = solver.initializeASCIIFiles(forceFile); CHKERRQ(ierr);
     
     // start time marching
     for (int ite=start+1; ite<=end; ite++)

--- a/applications/tairacolonius/tairacolonius.cpp
+++ b/applications/tairacolonius/tairacolonius.cpp
@@ -346,9 +346,7 @@ PetscErrorCode TairaColoniusSolver::writeIntegratedForces(
             const PetscReal &t, const std::string &filePath)
 {
     PetscErrorCode ierr;
-    PetscViewer         viewer;
     petibm::type::RealVec2D     fAvg;
-    static PetscFileMode mode = FILE_MODE_WRITE;
 
     PetscFunctionBeginUser;
 
@@ -362,14 +360,9 @@ PetscErrorCode TairaColoniusSolver::writeIntegratedForces(
     
     ierr = PetscLogStagePop(); CHKERRQ(ierr);
     
-    // create ASCII viewer
-    ierr = PetscViewerCreate(PETSC_COMM_WORLD, &viewer); CHKERRQ(ierr);
-    ierr = PetscViewerSetType(viewer, PETSCVIEWERASCII); CHKERRQ(ierr);
-    ierr = PetscViewerFileSetMode(viewer, mode); CHKERRQ(ierr);
-    ierr = PetscViewerFileSetName(viewer, filePath.c_str()); CHKERRQ(ierr);
-    
     // write current time
-    ierr = PetscViewerASCIIPrintf(viewer, "%10.8e", t); CHKERRQ(ierr);
+    ierr = PetscViewerASCIIPrintf(
+            asciiViewers[filePath], "%10.8e", t); CHKERRQ(ierr);
     
     // write forces body by body
     for(unsigned int i=0; i<bodies->nBodies; ++i)
@@ -377,16 +370,10 @@ PetscErrorCode TairaColoniusSolver::writeIntegratedForces(
         for(unsigned int d=0; d<mesh->dim; ++d)
         {
             ierr = PetscViewerASCIIPrintf(
-                    viewer, "\t%10.8e", fAvg[i][d]); CHKERRQ(ierr);
+                    asciiViewers[filePath], "\t%10.8e", fAvg[i][d]); CHKERRQ(ierr);
         }
     }
-    ierr = PetscViewerASCIIPrintf(viewer, "\n"); CHKERRQ(ierr);
+    ierr = PetscViewerASCIIPrintf(asciiViewers[filePath], "\n"); CHKERRQ(ierr);
     
-    // destroy
-    ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
-    
-    // next we'll just append data
-    mode = FILE_MODE_APPEND;
-
     PetscFunctionReturn(0);
 } // writeIntegratedForces

--- a/applications/tairacolonius/tairacolonius.h
+++ b/applications/tairacolonius/tairacolonius.h
@@ -22,8 +22,6 @@ public:
 
     // public methods that don't change
     using NavierStokesSolver::advance;
-    using NavierStokesSolver::writeRestartData;
-    using NavierStokesSolver::readRestartData;
     using NavierStokesSolver::writeIterations;
     
     /** \brief Default constructor.  */
@@ -67,6 +65,23 @@ public:
      * \param filePath [in] path of the file to save (without the extension)
      */
     PetscErrorCode write(const std::string &filePath);
+    
+    /**
+     * \brief Write the extra data that are required for restarting sessions.
+     * 
+     * If the file already has solutions in it, only extra necessary data will
+     * be writen in. Otherwise, solutions and extra data will all be writen in.
+     *
+     * \param filePath [in] path of the file to save (without the extension)
+     */
+    PetscErrorCode writeRestartData(const std::string &filePath);
+    
+    /**
+     * \brief read data that are required for restarting sessions.
+     * 
+     * \param filePath [in] path of the file to save (without the extension)
+     */
+    PetscErrorCode readRestartData(const std::string &filePath);
 
     /**
      * \brief Write the integrated forces acting on the bodies into a ASCII file.

--- a/applications/tairacolonius/tairacolonius.h
+++ b/applications/tairacolonius/tairacolonius.h
@@ -22,6 +22,7 @@ public:
 
     // public methods that don't change
     using NavierStokesSolver::advance;
+    using NavierStokesSolver::initializeASCIIFiles;
     using NavierStokesSolver::writeIterations;
     
     /** \brief Default constructor.  */

--- a/applications/tairacolonius/tairacolonius.h
+++ b/applications/tairacolonius/tairacolonius.h
@@ -47,7 +47,10 @@ public:
     /**
      * \brief Default destructor.
      */
-    ~TairaColoniusSolver() = default;
+    ~TairaColoniusSolver();
+
+    /** \brief manually destroy data.  */
+    PetscErrorCode destroy();
 
     /**
      * \brief Initialize vectors, operators, and linear solvers.
@@ -73,11 +76,6 @@ public:
      */
     PetscErrorCode writeIntegratedForces(
             const PetscReal &t, const std::string &filePath);
-
-    /**
-     * \brief Destroy PETSc objects (vectors and matrices) and linear solvers.
-     */
-    PetscErrorCode finalize();
 
     
 protected:

--- a/include/petibm/bodypack.h
+++ b/include/petibm/bodypack.h
@@ -72,7 +72,15 @@ public:
 
 
     /** \brief default destructor. */
-    ~BodyPackBase() = default;
+    virtual ~BodyPackBase();
+
+
+    /**
+     * \brief manually destroy data.
+     *
+     * \return PetscErrorCode.
+     */
+    virtual PetscErrorCode destroy();
 
 
     /**

--- a/include/petibm/boundary.h
+++ b/include/petibm/boundary.h
@@ -46,7 +46,15 @@ public:
     BoundaryBase(const type::Mesh &mesh, const YAML::Node &node);
 
     /** \brief default destructor. */
-    virtual ~BoundaryBase() = default;
+    virtual ~BoundaryBase();
+
+
+    /**
+     * \brief manually destroy data.
+     *
+     * \return PetscErrorCode.
+     */
+    virtual PetscErrorCode destroy();
 
 
     /**

--- a/include/petibm/boundarysimple.h
+++ b/include/petibm/boundarysimple.h
@@ -32,7 +32,7 @@ public:
     BoundarySimple(const type::Mesh &mesh, const YAML::Node &node);
 
     /** \copydoc petibm::boundary::BoundaryBase::~BoundaryBase */
-    virtual ~BoundarySimple();
+    virtual ~BoundarySimple() = default;
 
 
     /** \copydoc petibm::boundary::BoundaryBase::setGhostICs */

--- a/include/petibm/cartesianmesh.h
+++ b/include/petibm/cartesianmesh.h
@@ -42,6 +42,10 @@ public:
 
     /** \brief default destructor. */
     virtual ~CartesianMesh();
+
+
+    /** \copydoc petibm::mesh::MeshBase::destroy */
+    virtual PetscErrorCode destroy();
     
     /** \copydoc petibm::mesh::MeshBase::write */
     virtual PetscErrorCode write(const std::string &filePath) const;

--- a/include/petibm/linsolver.h
+++ b/include/petibm/linsolver.h
@@ -47,6 +47,13 @@ public:
 
     /** \brief virtual destruction function. */
     virtual ~LinSolverBase() = default;
+
+    /**
+     * \brief Manually destroy the instance.
+     *
+     * \return  PetscErrorCode.
+     */
+    virtual PetscErrorCode destroy();
     
     /**
      * \brief print information to standard output.

--- a/include/petibm/linsolveramgx.h
+++ b/include/petibm/linsolveramgx.h
@@ -30,6 +30,9 @@ public:
     /** \brief destructor. */
     virtual ~LinSolverAmgX();
 
+    /** \brief LinSolverBase::destroy. */
+    virtual PetscErrorCode destroy();
+
     /** \copydoc LinSolverBase::setMatrix. */
     virtual PetscErrorCode setMatrix(const Mat &A);
 

--- a/include/petibm/linsolverksp.h
+++ b/include/petibm/linsolverksp.h
@@ -30,6 +30,9 @@ public:
     /** \brief destructor. */
     virtual ~LinSolverKSP();
 
+    /** \brief LinSolverBase::destroy. */
+    virtual PetscErrorCode destroy();
+
     /** \copydoc LinSolverBase::setMatrix. */
     virtual PetscErrorCode setMatrix(const Mat &A);
 

--- a/include/petibm/mesh.h
+++ b/include/petibm/mesh.h
@@ -119,7 +119,15 @@ public:
 
 
     /** \brief default destructor. */
-    virtual ~MeshBase() = default;
+    virtual ~MeshBase();
+
+
+    /**
+     * \brief manually destroy data.
+     *
+     * \return PetscErrorCode.
+     */
+    virtual PetscErrorCode destroy();
     
 
     /**

--- a/include/petibm/singlebody.h
+++ b/include/petibm/singlebody.h
@@ -86,7 +86,15 @@ public:
 
 
     /** \brief the default destructor. */
-    virtual ~SingleBodyBase() = default;
+    virtual ~SingleBodyBase();
+
+
+    /**
+     * \brief manually destroy data.
+     *
+     * \return PetscErrorCode.
+     */
+    virtual PetscErrorCode destroy();
     
     
     /**

--- a/include/petibm/singleboundary.h
+++ b/include/petibm/singleboundary.h
@@ -74,7 +74,15 @@ public:
             const type::BCType &type, const PetscReal &value); 
 
     /** \brief default destructor. */
-    virtual ~SingleBoundaryBase() = default;
+    virtual ~SingleBoundaryBase();
+
+
+    /**
+     * \brief manually destroy data.
+     *
+     * \return PetscErrorCode.
+     */
+    virtual PetscErrorCode destroy();
 
 
     /**

--- a/include/petibm/singleboundaryconvective.h
+++ b/include/petibm/singleboundaryconvective.h
@@ -27,6 +27,8 @@ public:
 
     virtual ~SingleBoundaryConvective() = default;
 
+    virtual PetscErrorCode destroy();
+
 protected:
 
     virtual PetscErrorCode setGhostICsKernel(

--- a/include/petibm/solution.h
+++ b/include/petibm/solution.h
@@ -53,7 +53,14 @@ public:
     SolutionBase(const type::Mesh &mesh) {};
 
     /** \brief default destructor. */
-    virtual ~SolutionBase() = default;
+    virtual ~SolutionBase();
+
+    /**
+     * \brief manually destroy data.
+     *
+     * \return PetscErrorCode.
+     */
+    virtual PetscErrorCode destroy();
     
     /**
      * \brief print information to standard output.

--- a/src/body/bodypack.cpp
+++ b/src/body/bodypack.cpp
@@ -24,6 +24,41 @@ BodyPackBase::BodyPackBase(const type::Mesh &inMesh, const YAML::Node &node)
 }
 
 
+BodyPackBase::~BodyPackBase()
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode ierr;
+    PetscBool finalized;
+
+    ierr = PetscFinalized(&finalized); CHKERRV(ierr);
+    if (finalized) return;
+
+    ierr = DMDestroy(&dmPack); CHKERRV(ierr);
+    comm = MPI_COMM_NULL;
+}
+
+
+PetscErrorCode BodyPackBase::destroy()
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode ierr;
+
+    dim = -1;
+    nBodies = nPts = nLclPts = 0;
+    std::vector<type::SingleBody>().swap(bodies);
+    ierr = DMDestroy(&dmPack); CHKERRQ(ierr);
+    info = "";
+
+    mesh.reset();
+    comm = MPI_COMM_NULL;
+    mpiSize = mpiRank = 0;
+    type::IntVec1D().swap(nLclAllProcs);
+    type::IntVec1D().swap(offsetsAllProcs);
+
+    PetscFunctionReturn(0);
+}
+
+
 PetscErrorCode BodyPackBase::init(
         const type::Mesh &inMesh, const YAML::Node &node)
 {

--- a/src/body/singlebody.cpp
+++ b/src/body/singlebody.cpp
@@ -44,6 +44,41 @@ SingleBodyBase::SingleBodyBase(const type::Mesh &inMesh,
 }
 
 
+SingleBodyBase::~SingleBodyBase()
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode  ierr;
+    PetscBool finalized;
+
+    ierr = PetscFinalized(&finalized); CHKERRV(ierr);
+    if (finalized) return;
+
+    ierr = DMDestroy(&da); CHKERRV(ierr);
+    comm = MPI_COMM_NULL;
+}
+
+
+PetscErrorCode SingleBodyBase::destroy()
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode  ierr;
+
+    dim = -1;
+    name = file = info = "";
+    nPts = nLclPts = bgPt = edPt = 0;
+    type::RealVec2D().swap(coords);
+    type::IntVec2D().swap(meshIdx);
+    ierr = DMDestroy(&da); CHKERRQ(ierr);
+    comm = MPI_COMM_NULL;
+    mpiSize = mpiRank = 0;
+    mesh.reset();
+    type::IntVec1D().swap(nLclAllProcs);
+    type::IntVec1D().swap(offsetsAllProcs);
+
+    PetscFunctionReturn(0);
+}
+
+
 PetscErrorCode SingleBodyBase::printInfo() const
 {
     PetscFunctionBeginUser;

--- a/src/boundary/boundary.cpp
+++ b/src/boundary/boundary.cpp
@@ -14,6 +14,35 @@ namespace petibm
 namespace boundary
 {
 
+
+// default destructor
+BoundaryBase::~BoundaryBase()
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode ierr;
+    PetscBool finalized;
+
+    ierr = PetscFinalized(&finalized); CHKERRV(ierr);
+    if (finalized) return;
+
+    comm = MPI_COMM_NULL;
+}
+
+
+PetscErrorCode BoundaryBase::destroy()
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode ierr;
+
+    std::vector<std::vector<type::SingleBoundary>>().swap(bds);
+
+    comm = MPI_COMM_NULL;
+    mpiSize = mpiRank = 0;
+    mesh.reset();
+
+    PetscFunctionReturn(0);
+}
+
 PetscErrorCode createBoundary(
         const type::Mesh &mesh, const YAML::Node &node,
         type::Boundary &boundary)

--- a/src/boundary/boundarysimple.cpp
+++ b/src/boundary/boundarysimple.cpp
@@ -19,10 +19,6 @@ namespace boundary
 using namespace type;
 
 
-// default destructor
-BoundarySimple::~BoundarySimple() = default;
-
-
 // constructor
 BoundarySimple::BoundarySimple(const type::Mesh &inMesh, const YAML::Node &node)
 {

--- a/src/boundary/singleboundarybase.cpp
+++ b/src/boundary/singleboundarybase.cpp
@@ -24,6 +24,39 @@ SingleBoundaryBase::SingleBoundaryBase(const type::Mesh &inMesh,
 }
 
 
+SingleBoundaryBase::~SingleBoundaryBase()
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode ierr;
+    PetscBool finalized;
+
+    ierr = PetscFinalized(&finalized); CHKERRV(ierr);
+    if (finalized) return;
+
+    comm = MPI_COMM_NULL;
+}
+
+
+PetscErrorCode SingleBoundaryBase::destroy()
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode ierr;
+
+    dim = -1;
+    loc = type::BCLoc(0);
+    field = type::Field(0);
+    value = normal = 0.0;
+    type::GhostPointsList().swap(points);
+    onThisProc = PETSC_FALSE;
+
+    comm = MPI_COMM_NULL;
+    mpiSize = mpiRank = 0;
+    mesh.reset();
+
+    PetscFunctionReturn(0);
+}
+
+
 PetscErrorCode SingleBoundaryBase::init(const type::Mesh &inMesh,
         const type::BCLoc &bcLoc, const type::Field &inField,
         const type::BCType &inType, const PetscReal &inValue)

--- a/src/boundary/singleboundaryconvective.cpp
+++ b/src/boundary/singleboundaryconvective.cpp
@@ -57,6 +57,16 @@ SingleBoundaryConvective::SingleBoundaryConvective(
 }
 
 
+PetscErrorCode SingleBoundaryConvective::destroy()
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode ierr;
+    kernel = nullptr;
+    ierr = SingleBoundaryBase::destroy(); CHKERRQ(ierr);
+    PetscFunctionReturn(0);
+}
+
+
 PetscErrorCode SingleBoundaryConvective::setGhostICsKernel(
         const PetscReal &targetValue, type::GhostPointInfo &p)
 {

--- a/src/linsolver/linsolver.cpp
+++ b/src/linsolver/linsolver.cpp
@@ -19,6 +19,15 @@ namespace petibm
 {
 namespace linsolver
 {
+
+
+PetscErrorCode LinSolverBase::destroy()
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode  ierr;
+    name = config = type = "";
+    PetscFunctionReturn(0);
+}
     
     
 PetscErrorCode LinSolverBase::printInfo() const

--- a/src/linsolver/linsolverksp.cpp
+++ b/src/linsolver/linsolverksp.cpp
@@ -73,6 +73,7 @@ PetscErrorCode LinSolverKSP::setMatrix(const Mat &A)
 
     PetscErrorCode ierr;
 
+    ierr = KSPReset(ksp); CHKERRQ(ierr);
     ierr = KSPSetOperators(ksp, A, A); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);

--- a/src/linsolver/linsolverksp.cpp
+++ b/src/linsolver/linsolverksp.cpp
@@ -18,7 +18,30 @@ LinSolverKSP::LinSolverKSP(const std::string &_name, const std::string &_config)
 
 
 // destructor
-LinSolverKSP::~LinSolverKSP() = default;
+LinSolverKSP::~LinSolverKSP()
+{
+    PetscFunctionBeginUser;
+
+    PetscErrorCode ierr;
+    PetscBool finalized;
+
+    ierr = PetscFinalized(&finalized); CHKERRV(ierr);
+    if (finalized) return;
+
+    ierr = KSPDestroy(&ksp); CHKERRV(ierr);
+}
+
+
+// manually destroy
+PetscErrorCode LinSolverKSP::destroy()
+{
+    PetscErrorCode ierr;
+
+    ierr = KSPDestroy(&ksp); CHKERRQ(ierr);
+    ierr = LinSolverBase::destroy(); CHKERRQ(ierr);
+
+    PetscFunctionReturn(0);
+}
 
 
 // underlying initialization function
@@ -39,8 +62,6 @@ PetscErrorCode LinSolverKSP::init()
     ierr = KSPSetReusePreconditioner(ksp, PETSC_TRUE); CHKERRQ(ierr);
     ierr = KSPSetFromOptions(ksp); CHKERRQ(ierr);
     
-    ierr = PetscObjectRegisterDestroy((PetscObject) ksp); CHKERRQ(ierr);
-
     PetscFunctionReturn(0);
 }
 

--- a/src/mesh/cartesianmesh.cpp
+++ b/src/mesh/cartesianmesh.cpp
@@ -39,7 +39,38 @@ CartesianMesh::CartesianMesh(const MPI_Comm &world, const YAML::Node &node)
 
 
 // default destructor
-CartesianMesh::~CartesianMesh() = default;
+CartesianMesh::~CartesianMesh()
+{
+    PetscFunctionBeginUser;
+
+    PetscErrorCode      ierr;
+    PetscBool finalized;
+
+    ierr = PetscFinalized(&finalized); CHKERRV(ierr);
+    if (finalized) return;
+
+    std::vector<AO>().swap(ao); // DO NOT DESTROY UNDERLYING AOs!!
+}
+
+
+// manually destroy data
+PetscErrorCode CartesianMesh::destroy()
+{
+    PetscFunctionBeginUser;
+
+    PetscErrorCode      ierr;
+
+    type::RealVec3D().swap(dLTrue);
+    type::RealVec3D().swap(coordTrue);
+    std::vector<AO>().swap(ao); // DO NOT DESTROY UNDERLYING AOs!!
+    type::IntVec1D().swap(UPackNLocalAllProcs);
+    type::IntVec2D().swap(offsetsAllProcs);
+    type::IntVec1D().swap(offsetsPackAllProcs);
+
+    ierr = MeshBase::destroy(); CHKERRQ(ierr);
+
+    PetscFunctionReturn(0);
+}
 
 
 // initialization

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -14,6 +14,64 @@ namespace petibm
 {
 namespace mesh
 {
+    MeshBase::~MeshBase()
+    {
+        PetscFunctionBeginUser;
+
+        PetscErrorCode ierr;
+        PetscBool finalized;
+
+        ierr = PetscFinalized(&finalized); CHKERRV(ierr);
+        if (finalized) return;
+
+        for(int f=0; f<dim; ++f)
+        {
+            ierr = DMDestroy(&da[f]); CHKERRV(ierr);
+        }
+        ierr = DMDestroy(&da[3]); CHKERRV(ierr);
+        ierr = DMDestroy(&da[4]); CHKERRV(ierr);
+        ierr = DMDestroy(&UPack); CHKERRV(ierr);
+        comm = MPI_COMM_NULL;
+    }
+
+
+    PetscErrorCode MeshBase::destroy()
+    {
+        PetscFunctionBeginUser;
+        
+        PetscErrorCode ierr;
+
+        dim = -1;
+        type::RealVec1D().swap(min);
+        type::RealVec1D().swap(max);
+        type::IntVec2D().swap(n);
+        type::BoolVec2D().swap(periodic);
+        type::GhostedVec3D().swap(coord);
+        type::GhostedVec3D().swap(dL);
+        UN = pN = 0;
+        info = std::string();
+
+        for(int f=0; f<dim; ++f)
+        {
+            ierr = DMDestroy(&da[f]); CHKERRQ(ierr);
+        }
+        ierr = DMDestroy(&da[3]); CHKERRQ(ierr);
+        ierr = DMDestroy(&da[4]); CHKERRQ(ierr);
+
+        type::IntVec1D().swap(nProc);
+        type::IntVec2D().swap(bg);
+        type::IntVec2D().swap(ed);
+        type::IntVec2D().swap(m);
+        UNLocal = pNLocal = 0;
+        ierr = DMDestroy(&UPack); CHKERRQ(ierr);
+
+        comm = MPI_COMM_NULL;
+        mpiSize = mpiRank = 0;
+        
+        PetscFunctionReturn(0);
+    }
+
+
     PetscErrorCode MeshBase::printInfo() const
     {
         PetscFunctionBeginUser;

--- a/src/solution/solution.cpp
+++ b/src/solution/solution.cpp
@@ -14,6 +14,39 @@ namespace petibm
 {
 namespace solution
 {
+    SolutionBase::~SolutionBase()
+    {
+        PetscFunctionBeginUser;
+        PetscErrorCode ierr;
+        PetscBool finalized;
+
+        ierr = PetscFinalized(&finalized); CHKERRV(ierr);
+        if (finalized) return;
+
+        ierr = VecDestroy(&UGlobal); CHKERRV(ierr);
+        ierr = VecDestroy(&pGlobal); CHKERRV(ierr);
+        comm = MPI_COMM_NULL;
+    }
+
+
+    PetscErrorCode SolutionBase::destroy()
+    {
+        PetscFunctionBeginUser;
+        PetscErrorCode ierr;
+
+        dim = -1;
+        ierr = VecDestroy(&UGlobal); CHKERRQ(ierr);
+        ierr = VecDestroy(&pGlobal); CHKERRQ(ierr);
+        info = "";
+
+        comm = MPI_COMM_NULL;
+        mpiRank = mpiSize = 0;
+        mesh.reset();
+
+        PetscFunctionReturn(0);
+    }
+
+
     PetscErrorCode SolutionBase::printInfo() const
     {
         PetscFunctionBeginUser;


### PR DESCRIPTION
1. Fix destructor and destroy functions so that there should be no more error message at the end of simulations. (messages regarding MPI_Comm_free and double-linked data). This should fix #102.

2. Add KSPReset to LinSolverKSP. Every time we modify the operator of an existing KSP solver, we should reset the counter of the KSP solver so that the preconditioner can be re-calculated.

3. Fix #103.

4. Fix broken restarting functionality of Taira-Colonius solver.