### PR TITLE
Cache PETSc for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,31 +17,27 @@ before_install:
   - export CC="gcc-6"
   - export CXX="g++-6"
   - export FC="gfortran-6"
-  - export PETIBM_DIR=$PWD
-  - $CC --version
-  - $CXX --version
-  - $FC --version
+  - export PETIBM_DIR=$TRAVIS_BUILD_DIR
+  - mkdir -p $PETIBM_DIR
+  - export PETSC_DIR=$TRAVIS_BUILD_DIR/petsc
+  - mkdir -p $PETSC_DIR
+  - export PETSC_ARCH=linux-dbg
 
 install:
-  # install PETSc-3.8.2
-  - cd ..
-  - wget "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.8.2.tar.gz" -O /tmp/petsc-lite-3.8.2.tar.gz
-  - tar xfz /tmp/petsc-lite-3.8.2.tar.gz
-  - cd petsc-3.8.2
-  - export PETSC_DIR=$PWD
-  - export PETSC_ARCH=arch-dbg
-  - ./configure --PETSC_ARCH=$PETSC_ARCH --with-cc=$CC --with-cxx=$CXX --with-fc=0 --COPTFLAGS="-O0" --CXXOPTFLAGS="-O0" --FOPTFLAGS="-O0" --with-debugging=1 --download-f2cblaslapack --download-hdf5 --download-openmpi
-  - make all
+  - ./scripts/travis-install-petsc.sh $PETSC_DIR $PETSC_ARCH
 
 script:
-  # build PetIBM
   - cd $PETIBM_DIR
   - mkdir build
   - cd build
-  - $PETIBM_DIR/configure --prefix=$PWD CXX=$PETSC_DIR/$PETSC_ARCH/bin/mpicxx CXXFLAGS="-g -O0 -std=c++11" --with-petsc-dir=$PETSC_DIR --with-petsc-arch=$PETSC_ARCH --enable-yamlcpp --enable-boost --enable-gtest
-  - make all
+  - $PETIBM_DIR/configure --prefix=$PETIBM_DIR/install CXX=$PETSC_DIR/$PETSC_ARCH/bin/mpicxx CXXFLAGS="-g -O0 -Wno-deprecated -std=c++11" --with-petsc-dir=$PETSC_DIR --with-petsc-arch=$PETSC_ARCH --enable-yamlcpp --enable-boost --enable-gtest
+  - make all -j2
   - make check
   - make install
+
+cache:
+  directories:
+    - petsc
 
 notifications:
   email: false

--- a/scripts/travis-install-petsc.sh
+++ b/scripts/travis-install-petsc.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Install PETSc-3.8.2 in debug mode.
+# Use the cached PETSc if mpicxx is detected.
+
+PETSC_DIR=$1
+PETSC_ARCH=$2
+
+if [ -f "$PETSC_DIR/$PETSC_ARCH/bin/mpicxx" ]; then
+  echo "Using cached PETSc"
+  echo "Configuring PETSc"
+  cd $PETSC_DIR
+  ./configure PETSC_ARCH=$PETSC_ARCH \
+    --with-cc=$CC --with-cxx=$CXX --with-fc=0 \
+    --COPTFLAGS="-O0" --CXXOPTFLAGS="-O0" --FOPTFLAGS="-O0" \
+    --with-debugging=1 \
+    --download-f2cblaslapack --download-hdf5 --download-openmpi
+else
+  echo "Downloading PETSc"
+  URL="http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.8.2.tar.gz"
+  TARBALL=/tmp/petsc-lite-3.8.2.tar.gz
+  wget $URL -O $TARBALL
+  tar xfz $TARBALL -C $PETSC_DIR --strip-components=1
+  rm -f $TARBALL
+  echo "Configuring and building PETSc"
+  cd $PETSC_DIR
+  ./configure PETSC_ARCH=$PETSC_ARCH \
+    --with-cc=$CC --with-cxx=$CXX --with-fc=0 \
+    --COPTFLAGS="-O0" --CXXOPTFLAGS="-O0" --FOPTFLAGS="-O0" \
+    --with-debugging=1 \
+    --download-f2cblaslapack --download-hdf5 --download-openmpi
+  make PETSC_DIR=$PETSC_DIR PETSC_ARCH=$PETSC_ARCH all
+  make PETSC_DIR=$PETSC_DIR PETSC_ARCH=$PETSC_ARCH test
+fi


### PR DESCRIPTION
Cache the PETSc directory to accelerate the Travis build.
Right now, we are using PETSc-3.8.2.