### PR TITLE
LinSolverKSP::solve: PetscFunctionReturn

### DIFF
--- a/src/linsolver/linsolverksp.cpp
+++ b/src/linsolver/linsolverksp.cpp
@@ -110,7 +110,7 @@ PetscErrorCode LinSolverKSP::solve(Vec &x, Vec &b)
                 "reason %d.", name.c_str(), reason);
     }
 
-    return 0;
+    PetscFunctionReturn(0);
 } // solve
 
 


### PR DESCRIPTION
Every PetscFunctionBeginUser must be matched with PetscFunctionReturn,
otherwise PETSc's debugging stack will become corrupted.