### PR TITLE
Joss review: fix #130

### DIFF
--- a/applications/createxdmf/main.cpp
+++ b/applications/createxdmf/main.cpp
@@ -115,7 +115,10 @@ int main(int argc, char **argv)
         ierr = writeSingleXDMF(setting["directory"].as<std::string>(),
                 "wy", mesh->dim, wn, bg, ed, step); CHKERRQ(ierr);
     }
-    
+
+    // manually destroy PETSc objects inside the mesh instance
+    ierr = mesh->destroy(); CHKERRQ(ierr);
+
     ierr = PetscFinalize(); CHKERRQ(ierr);
     
     return 0;

--- a/applications/decoupledibpm/main.cpp
+++ b/applications/decoupledibpm/main.cpp
@@ -187,6 +187,12 @@ int main(int argc, char **argv)
         ierr = solver.writeIntegratedForces(t, forceFile); CHKERRQ(ierr);
     }
 
+    // manually destroy PETSc objects before PetscFinalize
+    ierr = solver.destroy(); CHKERRQ(ierr);
+    ierr = bodies->destroy(); CHKERRQ(ierr);
+    ierr = bd->destroy(); CHKERRQ(ierr);
+    ierr = mesh->destroy(); CHKERRQ(ierr);
+
     ierr = PetscFinalize(); CHKERRQ(ierr);
     
     return 0;

--- a/applications/navierstokes/main.cpp
+++ b/applications/navierstokes/main.cpp
@@ -180,6 +180,11 @@ int main(int argc, char **argv)
         }
     }
 
+    // manually destroy the solver and PETSc objects in it
+    ierr = solver.destroy(); CHKERRQ(ierr);
+    ierr = bd->destroy(); CHKERRQ(ierr);
+    ierr = mesh->destroy(); CHKERRQ(ierr);
+
     ierr = PetscFinalize(); CHKERRQ(ierr);
     
     return 0;

--- a/applications/tairacolonius/main.cpp
+++ b/applications/tairacolonius/main.cpp
@@ -186,6 +186,12 @@ int main(int argc, char **argv)
         ierr = solver.writeIntegratedForces(t, forceFile); CHKERRQ(ierr);
     }
 
+    // manually destroy PETSc objects before PetscFinalize
+    ierr = solver.destroy(); CHKERRQ(ierr);
+    ierr = bodies->destroy(); CHKERRQ(ierr);
+    ierr = bd->destroy(); CHKERRQ(ierr);
+    ierr = mesh->destroy(); CHKERRQ(ierr);
+
     ierr = PetscFinalize(); CHKERRQ(ierr);
     
     return 0;

--- a/applications/tairacolonius/tairacolonius.cpp
+++ b/applications/tairacolonius/tairacolonius.cpp
@@ -52,6 +52,7 @@ PetscErrorCode TairaColoniusSolver::destroy()
     bodies.reset();
     ierr = ISDestroy(&isDE[0]); CHKERRQ(ierr);
     ierr = ISDestroy(&isDE[1]); CHKERRQ(ierr);
+    ierr = VecResetArray(P); CHKERRQ(ierr);
     ierr = VecDestroy(&P); CHKERRQ(ierr);
     ierr = NavierStokesSolver::destroy(); CHKERRQ(ierr);
 
@@ -180,11 +181,14 @@ PetscErrorCode TairaColoniusSolver::createVectors()
     solution->pGlobal = P;
     P = temp;
     temp = PETSC_NULL;
+
+    // destroy P's underlying raw array but keep all other information
+    ierr = VecReplaceArray(P, nullptr); CHKERRQ(ierr);
     
     // reset the underlying data of P to the pressure portion in pGlobal
     ierr = VecGetSubVector(solution->pGlobal, isDE[0], &temp); CHKERRQ(ierr);
     ierr = VecGetArrayRead(temp, &data); CHKERRQ(ierr);
-    ierr = VecReplaceArray(P, data); CHKERRQ(ierr);
+    ierr = VecPlaceArray(P, data); CHKERRQ(ierr);
     ierr = VecRestoreArrayRead(temp, &data); CHKERRQ(ierr);
     ierr = VecRestoreSubVector(solution->pGlobal, isDE[0], &temp); CHKERRQ(ierr);
     

--- a/applications/vorticity/main.cpp
+++ b/applications/vorticity/main.cpp
@@ -171,7 +171,12 @@ int main(int argc, char **argv)
         ierr = VecDestroy(&w[f]); CHKERRQ(ierr);
         ierr = DMDestroy(&wDMs[f]); CHKERRQ(ierr);
     }
-    
+
+    // manually destroy PETSc objects inside the PetIBM objects
+    ierr = soln->destroy(); CHKERRQ(ierr);
+    ierr = bc->destroy(); CHKERRQ(ierr);
+    ierr = mesh->destroy(); CHKERRQ(ierr);
+
 
     ierr = PetscFinalize(); CHKERRQ(ierr);
 

--- a/examples/decoupledibpm/cylinder2dRe550_GPU/config.yaml
+++ b/examples/decoupledibpm/cylinder2dRe550_GPU/config.yaml
@@ -58,7 +58,7 @@ parameters:
     config: solversAmgXOptions.info
   forcesSolver:
     type: CPU
-    config: solversPestcOptions.info
+    config: solversPetscOptions.info
 
 bodies:
   - type: points

--- a/src/linsolver/linsolveramgx.cpp
+++ b/src/linsolver/linsolveramgx.cpp
@@ -14,21 +14,6 @@
 #include <petibm/linsolveramgx.h>
 
 
-// a global (in this file scope) vector of references to AmgXSolvers
-std::vector<AmgXSolver*> solvers;
-
-// a wrapper function for PetscFinalize() to destroy AmgXSolvers automatically
-PetscErrorCode preDestroyAmgXSolvers()
-{
-    PetscFunctionBeginUser;
-    PetscErrorCode ierr;
-    for(auto &it: solvers)
-    {
-        ierr = it->finalize(); CHKERRQ(ierr);
-    }
-    PetscFunctionReturn(0);
-} // preDestroyAmgXSolvers
-
 namespace petibm
 {
 namespace linsolver
@@ -88,9 +73,6 @@ PetscErrorCode LinSolverAmgX::init()
     }
 
     ierr = amgx.initialize(PETSC_COMM_WORLD, "dDDI", config); CHKERRQ(ierr);
-
-    solvers.push_back(&amgx);
-    ierr = PetscRegisterFinalize(&preDestroyAmgXSolvers); CHKERRQ(ierr);
 
     // remove temporary file if necessary
     if (config == "solversAmgXOptions-tmp.info")

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -14,7 +14,7 @@ namespace petibm
 {
 namespace mesh
 {
-    
+
 // implement MeshBase::~MeshBase
 MeshBase::~MeshBase()
 {
@@ -43,6 +43,14 @@ PetscErrorCode MeshBase::destroy()
 
     PetscErrorCode ierr;
 
+    for(int f=0; f<dim; ++f)
+    {
+        ierr = DMDestroy(&da[f]); CHKERRQ(ierr);
+    }
+    ierr = DMDestroy(&da[3]); CHKERRQ(ierr);
+    ierr = DMDestroy(&da[4]); CHKERRQ(ierr);
+    ierr = DMDestroy(&UPack); CHKERRQ(ierr);
+
     dim = -1;
     type::RealVec1D().swap(min);
     type::RealVec1D().swap(max);
@@ -53,19 +61,11 @@ PetscErrorCode MeshBase::destroy()
     UN = pN = 0;
     info = std::string();
 
-    for(int f=0; f<dim; ++f)
-    {
-        ierr = DMDestroy(&da[f]); CHKERRQ(ierr);
-    }
-    ierr = DMDestroy(&da[3]); CHKERRQ(ierr);
-    ierr = DMDestroy(&da[4]); CHKERRQ(ierr);
-
     type::IntVec1D().swap(nProc);
     type::IntVec2D().swap(bg);
     type::IntVec2D().swap(ed);
     type::IntVec2D().swap(m);
     UNLocal = pNLocal = 0;
-    ierr = DMDestroy(&UPack); CHKERRQ(ierr);
 
     comm = MPI_COMM_NULL;
     mpiSize = mpiRank = 0;
@@ -83,7 +83,7 @@ PetscErrorCode MeshBase::printInfo() const
 
     PetscFunctionReturn(0);
 } // printInfo
-    
+
 // implement petibm::mesh::createMesh
 PetscErrorCode createMesh(const MPI_Comm &comm,
         const YAML::Node &node, type::Mesh &mesh)


### PR DESCRIPTION
The PR resolves the issue of memory leaks in #130.

I found most of the memory leaks were coming from our side, while some of them may come from the HDF5 viewers in PETSc itself. I could only handle our side and couldn't do anything in the HDF5/PETSc part.

In additions, I am pretty sure these memory leaks didn't affect any simulation results. It was just that the memory of PETSc objects was not completely freed before `main` programs ended. And actually, I believe once the programs ended, the memory space was automatically freed by the system. So these leaks affected neither simulations nor system memory.

## Part 1: PetIBM side

### Description

1. The first problem came from the `Mesh` object. When we destroyed a `Mesh` object, we used a `for` loop with upper limit `dim` to sequentially destroy the `DMDA`s of velocity fields. However, the `dim` was set to `-1` before we got into the `for` loop. So those `DMDA`s were never destroyed. 

2. The second problem was that we didn't manually destroy the underlying PETSc objects in `Mesh`, `Boundary`, and `BodyPack` objects by the end of simulations.  Given that we have to destroy all PETSc objects before `PetscFinalize()`, we have to manually call the `destroy()` members of these PetIBM objects and can not rely on the destructor mechanism in C++. This is annoying, but I couldn't think of any other easy solutions.

3. Before this PR, in `TairaColoniusSolver`, the `P` vector was a vector created with a `DMDA` object but with a different underlying raw array from the original one. The assigned raw array was a part of `solution->pGlobal`, which is a vector of pressure plus Lagrangian forces. So when we destroyed `solution->pGlobal`, the underlying memory space of `P` was also destroyed. And then when `P` was destroyed, it could not properly destroy the underlying raw array. Or, if we destroyed `P` first, we would have the same problem when destroying `solution->pGlobal`. The solution is that we assign a dummy memory space to `P` first, and then use `VecPlaceArray` to assign partial `solution-pGlobal` to `P`. When we want to destroy `P` and `solution->pGlobal`, we can simply use `VecResetArray` to go back to the dummy memory space, and so `P` and `solution->pGlobal` are independent again.

### Test the PR

Use the following commands and preferred examples to test (with DEBUG version fo PETSc):
`mpiexec -n <#> bin/petibm-navierstokes -malloc -mallot_test -directory <preferred examples>`
`mpiexec -n <#> bin/petibm-tairacolonius -malloc -mallot_test -directory <preferred examples>`
`mpiexec -n <#> bin/petibm-decoupledibpm -malloc -mallot_test -directory <preferred examples>`
`mpiexec -n <#> bin/petibm-vorticity -malloc -mallot_test -directory <preferred examples>`
`mpiexec -n <#> bin/petibm-createxdmf -malloc -mallot_test -directory <preferred examples>`

## Part 2: HDF5/PETSc

### Description

When using Valgrind to check the memory issue, many memory issues popped out, while these memory issues could not be seen by simply using the `-malloc_test` flag. Though not sure, I believe these memory issues are about HDF5 in PETSc. And so I'm not going to dig deep because it doesn't currently seem to be PetIBM-related.

An example of the Valgrind message is:

```
==15479== 2,240 bytes in 5 blocks are definitely lost in loss record 54 of 54
==15479==    at 0x73C9EDF: malloc (vg_replace_malloc.c:299)
==15479==    by 0x1FE37BE9: ???
==15479==    by 0x1EDC5CB0: ???
==15479==    by 0x1EBBC4B2: ???
==15479==    by 0x147441AE: mca_io_base_file_select (in /usr/lib/openmpi/libmpi.so.40.0.0)
==15479==    by 0x146CEFB4: ompi_file_open (in /usr/lib/openmpi/libmpi.so.40.0.0)
==15479==    by 0x14725BA5: PMPI_File_open (in /usr/lib/openmpi/libmpi.so.40.0.0)
==15479==    by 0x375E1F2: H5FD_mpio_open (H5FDmpio.c:1058)
==15479==    by 0x37528B8: H5FD_open (H5FD.c:992)
==15479==    by 0x3746AA4: H5F_open (H5Fint.c:987)
==15479==    by 0x3740692: H5Fopen (H5F.c:603)
==15479==    by 0x21B3596: PetscViewerFileSetName_HDF5 (hdf5v.c:242)
```

The PETSc version is 3.8.3, and HDF5 is the one PETSc automatically downloads and builds (i.e., with the flag `--download-hdf5`). I'm using OpenMPI 3.0.0.

### Reproducing the issue

Use the following command for any preferred example.

```
mpiexec -n <#> valgrind --leak-check=full <any solver> -directory <preferred example>
```
