### PR TITLE
use anonymous namespace to apply internal linkages

### DIFF
--- a/src/boundary/singleboundaryconvective.cpp
+++ b/src/boundary/singleboundaryconvective.cpp
@@ -8,48 +8,51 @@
 #include <petibm/singleboundaryconvective.h>
 
 
-PetscErrorCode kernelConvectiveDiffDir(
-        const PetscReal &targetValue, const PetscReal &dt, 
-        const PetscReal &normal, const PetscReal &value,
-        petibm::type::GhostPointInfo &p)
+namespace // anonymous namespace for internal linkage
 {
-    PetscFunctionBeginUser;
-    
-    p.a0 = -1.0;
-    p.a1 = p.value + targetValue - 
-        2.0 * normal * dt * value * (p.value - targetValue) / p.dL;
-    
-    PetscFunctionReturn(0);
-} // kernelConvectiveDiffDir
+    PetscErrorCode kernelConvectiveDiffDir(
+            const PetscReal &targetValue, const PetscReal &dt,
+            const PetscReal &normal, const PetscReal &value,
+            petibm::type::GhostPointInfo &p)
+    {
+        PetscFunctionBeginUser;
+
+        p.a0 = -1.0;
+        p.a1 = p.value + targetValue -
+            2.0 * normal * dt * value * (p.value - targetValue) / p.dL;
+
+        PetscFunctionReturn(0);
+    } // kernelConvectiveDiffDir
 
 
-PetscErrorCode kernelConvectiveSameDir(
-        const PetscReal &targetValue, const PetscReal &dt, 
-        const PetscReal &normal, const PetscReal &value,
-        petibm::type::GhostPointInfo &p)
-{
-    PetscFunctionBeginUser;
-    
-    p.a0 = 0.0;
-    p.a1 = p.value - normal * dt * value * (p.value - targetValue) / p.dL;
-    
-    PetscFunctionReturn(0);
-} // kernelConvectiveSameDir
+    PetscErrorCode kernelConvectiveSameDir(
+            const PetscReal &targetValue, const PetscReal &dt,
+            const PetscReal &normal, const PetscReal &value,
+            petibm::type::GhostPointInfo &p)
+    {
+        PetscFunctionBeginUser;
+
+        p.a0 = 0.0;
+        p.a1 = p.value - normal * dt * value * (p.value - targetValue) / p.dL;
+
+        PetscFunctionReturn(0);
+    } // kernelConvectiveSameDir
+}
 
 
 namespace petibm
 {
 namespace boundary
 {
-    
-    
+
+
 SingleBoundaryConvective::SingleBoundaryConvective(
         const type::Mesh &inMesh, const type::BCLoc &inLoc,
         const type::Field &inField, const PetscReal &inValue):
     SingleBoundaryBase(inMesh, inLoc, inField, type::CONVECTIVE, inValue)
 {
     PetscInt dir = int(loc) / 2;
-    
+
     if (dir == int(field))
         kernel = &kernelConvectiveSameDir;
     else
@@ -71,17 +74,17 @@ PetscErrorCode SingleBoundaryConvective::setGhostICsKernel(
         const PetscReal &targetValue, type::GhostPointInfo &p)
 {
     PetscFunctionBeginUser;
-    
+
     PetscErrorCode  ierr;
-    
+
     // at beginning (t=0), due to lack of information of previous solution,
-    // we just assume the ghost point has the same value as target boundary 
+    // we just assume the ghost point has the same value as target boundary
     // point does
-    p.value = targetValue; 
-    
+    p.value = targetValue;
+
     // due to p.value=targetValue, it doesn't matter how big is time-step size
     ierr = kernel(targetValue, 0.0, normal, value, p); CHKERRQ(ierr);
-    
+
     PetscFunctionReturn(0);
 } // setGhostICsKernel
 
@@ -92,9 +95,9 @@ PetscErrorCode SingleBoundaryConvective::updateEqsKernel(const PetscReal &target
     PetscFunctionBeginUser;
 
     PetscErrorCode  ierr;
-    
+
     ierr = kernel(targetValue, dt, normal, value, p); CHKERRQ(ierr);
-    
+
     PetscFunctionReturn(0);
 } // updateEqsKernel
 

--- a/src/boundary/singleboundaryconvective.cpp
+++ b/src/boundary/singleboundaryconvective.cpp
@@ -37,7 +37,7 @@ namespace // anonymous namespace for internal linkage
 
         PetscFunctionReturn(0);
     } // kernelConvectiveSameDir
-}
+} // end of anonymous namespace
 
 
 namespace petibm

--- a/src/operators/createdivergence.cpp
+++ b/src/operators/createdivergence.cpp
@@ -18,43 +18,92 @@
 # include <petibm/boundary.h>
 
 
+namespace // anonymous namespace for internal linkage
+{
+
+// a private struct for matrix-free constraint mat
+struct DivergenceCtx
+{
+    const petibm::type::Boundary    bc;
+    petibm::type::MatrixModifier    modifier;
+
+    DivergenceCtx(const petibm::type::Boundary &_bc):
+        bc(_bc), modifier(bc->dim) {};
+};
+
+
+// a function type for functions returning neighbor's stencil
+typedef std::function<MatStencil(
+        const PetscInt &, const PetscInt &, const PetscInt &)> GetNeighborFunc;
+
+
+// a function type for functions returning the value of a matrix entry
+typedef std::function<PetscReal(
+        const PetscInt &, const PetscInt &, const PetscInt &)> Kernel;
+
+
+// a user-defined MatMult for constraint mat
+PetscErrorCode DCorrectionMult(Mat mat, Vec x, Vec y)
+{
+    PetscFunctionBeginUser;
+
+    PetscErrorCode      ierr;
+
+    DivergenceCtx       *ctx;
+
+    // get the context
+    ierr = MatShellGetContext(mat, (void *) &ctx); CHKERRQ(ierr);
+
+    // zero the output vector
+    ierr = VecSet(y, 0.0); CHKERRQ(ierr);
+
+    // set the correction values to corresponding rows
+    for(PetscInt f=0; f<ctx->bc->dim; ++f)
+        for(auto &bd: ctx->bc->bds[f])
+            if (bd->onThisProc)
+                for(auto &pt: bd->points)
+                {
+                    ierr = VecSetValue(y, ctx->modifier[f][pt.first].row,
+                            ctx->modifier[f][pt.first].coeff * pt.second.a1,
+                            ADD_VALUES); CHKERRQ(ierr);
+                }
+
+    // assembly (not sure if this is necessary and if this causes overhead)
+    // but there is an implicit MPI barrier in assembly, which we definitely need
+    ierr = VecAssemblyBegin(y); CHKERRQ(ierr);
+    ierr = VecAssemblyEnd(y); CHKERRQ(ierr);
+
+    PetscFunctionReturn(0);
+} // DCorrectionMult
+
+
+// a user-defined MatDestroy for constraint mat
+PetscErrorCode DCorrectionDestroy(Mat mat)
+{
+    PetscFunctionBeginUser;
+
+    PetscErrorCode      ierr;
+    DivergenceCtx       *ctx;
+
+    // get the context
+    ierr = MatShellGetContext(mat, (void *) &ctx); CHKERRQ(ierr);
+
+    // deallocate the context
+    delete ctx;
+
+    PetscFunctionReturn(0);
+} // DCorrectionDestroy
+} // end of anonymous namespace
+
+
 namespace petibm
 {
 namespace operators
 {
 
-/** \brief a private struct for matrix-free constraint mat. */
-struct DivergenceCtx
-{
-    const type::Boundary    bc;
-    type::MatrixModifier    modifier;
-    
-    DivergenceCtx(const type::Boundary &_bc): 
-        bc(_bc), modifier(bc->dim) {};
-};
-
-
-/** \brief a user-defined MatMult for constraint mat. */
-PetscErrorCode DCorrectionMult(Mat mat, Vec x, Vec y);
-
-
-/** \brief a user-defined MatDestroy for constraint mat. */
-PetscErrorCode DCorrectionDestroy(Mat mat);
-
-
-/** \brief a function type for functions returning neighbor's stencil. */
-typedef std::function<MatStencil(
-        const PetscInt &, const PetscInt &, const PetscInt &)> GetNeighborFunc;
-
-
-/** \brief a function type for functions returning the value of a matrix entry. */
-typedef std::function<PetscReal(
-        const PetscInt &, const PetscInt &, const PetscInt &)> Kernel;
-
-
 // implementation of petibm::operators::createDivergence
 PetscErrorCode createDivergence(const type::Mesh &mesh,
-                                const type::Boundary &bc, 
+                                const type::Boundary &bc,
                                 Mat &D,
                                 Mat &DCorrection,
                                 const PetscBool &normalize)
@@ -62,7 +111,7 @@ PetscErrorCode createDivergence(const type::Mesh &mesh,
     PetscFunctionBeginUser;
 
     PetscErrorCode                  ierr;
-    
+
     std::vector<GetNeighborFunc>    getNeighbor(3);
 
     std::vector<Kernel>             kernel(3);
@@ -85,7 +134,7 @@ PetscErrorCode createDivergence(const type::Mesh &mesh,
 
     // set up kernel
     if (normalize)
-        kernel[0] = kernel[1] = kernel[2] = 
+        kernel[0] = kernel[1] = kernel[2] =
             std::bind([]() -> PetscReal { return 1.0; });
     else
     {
@@ -100,7 +149,7 @@ PetscErrorCode createDivergence(const type::Mesh &mesh,
 
     // create matrix
     ierr = MatCreate(mesh->comm, &D); CHKERRQ(ierr);
-    ierr = MatSetSizes(D, mesh->pNLocal, mesh->UNLocal, 
+    ierr = MatSetSizes(D, mesh->pNLocal, mesh->UNLocal,
             PETSC_DETERMINE, PETSC_DETERMINE); CHKERRQ(ierr);
     ierr = MatSetFromOptions(D); CHKERRQ(ierr);
     ierr = MatSeqAIJSetPreallocation(D, mesh->dim*2, nullptr); CHKERRQ(ierr);
@@ -119,7 +168,7 @@ PetscErrorCode createDivergence(const type::Mesh &mesh,
             for(PetscInt i=mesh->bg[3][0]; i<mesh->ed[3][0]; ++i)
             {
                 PetscInt    self;
-                
+
                 // row index is based on pressure grid
                 ierr = mesh->getGlobalIndex(3, {k, j, i, 0}, self); CHKERRQ(ierr);
 
@@ -141,11 +190,11 @@ PetscErrorCode createDivergence(const type::Mesh &mesh,
 
                     ierr = mesh->getPackedGlobalIndex(field, target, targetIdx); CHKERRQ(ierr);
 
-                    ierr = MatSetValue(D, self, targetIdx, 
+                    ierr = MatSetValue(D, self, targetIdx,
                             value, INSERT_VALUES); CHKERRQ(ierr);
 
                     // store the coefficient of ghost points for future use
-                    if (targetIdx == -1) 
+                    if (targetIdx == -1)
                         ctx->modifier[field][target] = {self, value};
 
 
@@ -155,11 +204,11 @@ PetscErrorCode createDivergence(const type::Mesh &mesh,
                     ierr = mesh->getPackedGlobalIndex(field, target, targetIdx); CHKERRQ(ierr);
 
                     // note the value for this face is just a negative version
-                    ierr = MatSetValue(D, self, targetIdx, 
+                    ierr = MatSetValue(D, self, targetIdx,
                             - value, INSERT_VALUES); CHKERRQ(ierr);
 
                     // store the coefficient of ghost points for future use
-                    if (targetIdx == -1) 
+                    if (targetIdx == -1)
                         ctx->modifier[field][target] = {self, - value};
                 }
             }
@@ -193,7 +242,7 @@ PetscErrorCode createDivergence(const type::Mesh &mesh,
 
     // create a matrix-free constraint matrix for boundary correction
     ierr = MatCreateShell(mesh->comm, mesh->pNLocal, mesh->UNLocal,
-            PETSC_DETERMINE, PETSC_DETERMINE, (void *) ctx, &DCorrection); 
+            PETSC_DETERMINE, PETSC_DETERMINE, (void *) ctx, &DCorrection);
     CHKERRQ(ierr);
 
     ierr = MatShellSetOperation(DCorrection, MATOP_MULT,
@@ -204,59 +253,6 @@ PetscErrorCode createDivergence(const type::Mesh &mesh,
 
     PetscFunctionReturn(0);
 } // createDivergence
-
-
-// implementation of DCorrectionMult
-PetscErrorCode DCorrectionMult(Mat mat, Vec x, Vec y)
-{
-    PetscFunctionBeginUser;
-
-    PetscErrorCode      ierr;
-
-    DivergenceCtx       *ctx;
-
-    // get the context
-    ierr = MatShellGetContext(mat, (void *) &ctx); CHKERRQ(ierr);
-
-    // zero the output vector
-    ierr = VecSet(y, 0.0); CHKERRQ(ierr);
-
-    // set the correction values to corresponding rows
-    for(PetscInt f=0; f<ctx->bc->dim; ++f)
-        for(auto &bd: ctx->bc->bds[f])
-            if (bd->onThisProc)
-                for(auto &pt: bd->points)
-                {
-                    ierr = VecSetValue(y, ctx->modifier[f][pt.first].row,
-                            ctx->modifier[f][pt.first].coeff * pt.second.a1, 
-                            ADD_VALUES); CHKERRQ(ierr);
-                }
-
-    // assembly (not sure if this is necessary and if this causes overhead)
-    // but there is an implicit MPI barrier in assembly, which we definitely need
-    ierr = VecAssemblyBegin(y); CHKERRQ(ierr);
-    ierr = VecAssemblyEnd(y); CHKERRQ(ierr);
-
-    PetscFunctionReturn(0);
-} // DCorrectionMult
-
-
-// implementation of DCorrectionDestroy
-PetscErrorCode DCorrectionDestroy(Mat mat)
-{
-    PetscFunctionBeginUser;
-
-    PetscErrorCode      ierr;
-    DivergenceCtx       *ctx;
-
-    // get the context
-    ierr = MatShellGetContext(mat, (void *) &ctx); CHKERRQ(ierr);
-
-    // deallocate the context
-    delete ctx;
-
-    PetscFunctionReturn(0);
-} // DCorrectionDestroy
 
 } // end of namespace operators
 } // end of namespace petibm

--- a/src/operators/createlaplacian.cpp
+++ b/src/operators/createlaplacian.cpp
@@ -20,177 +20,98 @@
 # include <petibm/misc.h>
 
 
-namespace petibm
-{
-namespace operators
+namespace // anonymous namespace for internal linkage
 {
 
-/** \brief a private struct for matrix-free constraint mat. */
+// a helper type definition for vector of MatStencil
+typedef std::vector<MatStencil> StencilVec;
+
+
+// a function type for functions returning neighbor stencils
+typedef std::function<StencilVec(const PetscInt &,
+        const PetscInt &, const PetscInt &)>            GetStencilsFunc;
+
+// a private struct for matrix-free constraint mat
 struct LagrangianCtx
 {
-    const type::Boundary    bc;
-    type::MatrixModifier    modifier;
-    
-    LagrangianCtx(const type::Boundary &_bc):
+    const petibm::type::Boundary    bc;
+    petibm::type::MatrixModifier    modifier;
+
+    LagrangianCtx(const petibm::type::Boundary &_bc):
         bc(_bc), modifier(bc->dim) {};
 };
 
 
-/** \brief a user-defined MatMult for constraint mat. */
-PetscErrorCode LCorrectionMult(Mat mat, Vec x, Vec y);
-
-
-/** \brief a user-defined MatDestroy for constraint mat. */
-PetscErrorCode LCorrectionDestroy(Mat mat);
-
-
-/** \brief a helper type definition for vector of MatStencil. */
-typedef std::vector<MatStencil> StencilVec;
-
-
-/** \brief a function type for functions returning neighbor stencils. */
-typedef std::function<StencilVec(const PetscInt &, 
-        const PetscInt &, const PetscInt &)>            GetStencilsFunc;
-
-
-/**
- * \brief a private function that sets values of a row in Laplacian.
- *
- * \param mesh an instance of CartesianMesh class.
- * \param bc an instance of Boundary class.
- * \param getStencils a function that returns stencils according to dim.
- * \param f the index of field (u=0, v=1, z=2).
- * \param i the x-index of current row in the Cartesian mesh.
- * \param j the y-index of current row in the Cartesian mesh.
- * \param k the z-index of current row in the Cartesian mesh.
- * \param L the Laplacian matrix.
- * \param rowModifiers an object holding information about where in a matrix 
- *                     should be modified.
- *
- * \return PetscErrorCode.
- */
-inline PetscErrorCode setRowValues(
-        const type::Mesh &mesh,
-        const type::Boundary &bc,
-        const GetStencilsFunc &getStencils,
-        const PetscInt &f, const PetscInt &i,
-        const PetscInt &j, const PetscInt &k,
-        Mat &L,
-        std::map<MatStencil, type::RowModifier> &rowModifiers);
-
-
-// implementation of petibm::operators::createLaplacian
-PetscErrorCode createLaplacian(const type::Mesh &mesh,
-                               const type::Boundary &bc, 
-                               Mat &L, Mat &LCorrection)
+// a user-defined MatMult for constraint mat
+PetscErrorCode LCorrectionMult(Mat mat, Vec x, Vec y)
 {
-    using namespace std::placeholders;
-
     PetscFunctionBeginUser;
 
-    PetscErrorCode                  ierr;
-    
-    GetStencilsFunc                 getStencils;
+    PetscErrorCode      ierr;
 
-    LagrangianCtx                   *ctx;
+    LagrangianCtx       *ctx;
 
+    // get the context
+    ierr = MatShellGetContext(mat, (void *) &ctx); CHKERRQ(ierr);
 
-    // initialize modifier, regardless what's inside it now
-    ctx = new LagrangianCtx(bc);
+    // zero the output vector
+    ierr = VecSet(y, 0.0); CHKERRQ(ierr);
 
-    // set up getStencils
-    if (mesh->dim == 2)
-        getStencils = 
-            [](const PetscInt &i, const PetscInt &j, const PetscInt &k)
-            -> StencilVec {
-                return {{k, j, i, 0}, 
-                        {k, j, i-1, 0}, {k, j, i+1, 0}, 
-                        {k, j-1, i, 0}, {k, j+1, i, 0}};
-            };
-    else // implies dim == 3
-        getStencils = 
-            [](const PetscInt &i, const PetscInt &j, const PetscInt &k)
-            -> StencilVec {
-                return {{k, j, i, 0}, 
-                        {k, j, i-1, 0}, {k, j, i+1, 0}, 
-                        {k, j-1, i, 0}, {k, j+1, i, 0},
-                        {k-1, j, i, 0}, {k+1, j, i, 0}};
-            };
-
-
-    // create matrix
-    ierr = DMCreateMatrix(mesh->UPack, &L); CHKERRQ(ierr);
-    ierr = MatSetFromOptions(L); CHKERRQ(ierr);
-    ierr = MatSetOption(L, MAT_KEEP_NONZERO_PATTERN, PETSC_FALSE); CHKERRQ(ierr);
-    ierr = MatSetOption(L, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE); CHKERRQ(ierr);
-
-
-    // set values, one field each time
-    for(PetscInt field=0; field<mesh->dim; ++field)
-    {
-        // set row values
-        // the std::bind originally only binds values, in order to use
-        // reference instead of value-copying, we have to use std::ref
-        ierr = misc::tripleLoops(
-                {mesh->bg[field][2], mesh->ed[field][2]},
-                {mesh->bg[field][1], mesh->ed[field][1]},
-                {mesh->bg[field][0], mesh->ed[field][0]},
-                std::bind(setRowValues, 
-                    std::ref(mesh), std::ref(bc), std::ref(getStencils), 
-                    std::ref(field), _3, _2, _1, std::ref(L), 
-                    std::ref(ctx->modifier[field])));
-        CHKERRQ(ierr);
-    }
-
-
-    // temporarily assemble matrix
-    ierr = MatAssemblyBegin(L, MAT_FLUSH_ASSEMBLY); CHKERRQ(ierr);
-    ierr = MatAssemblyEnd(L, MAT_FLUSH_ASSEMBLY); CHKERRQ(ierr);
-
-
-    // TODO: check if a0 coefficients are already up-to-date.
-    for(PetscInt f=0; f<mesh->dim; ++f)
-        for(auto &bd: bc->bds[f])
+    // set the correction values to corresponding rows
+    for(PetscInt f=0; f<ctx->bc->dim; ++f)
+        for(auto &bd: ctx->bc->bds[f])
             if (bd->onThisProc)
                 for(auto &pt: bd->points)
                 {
-                    PetscInt    col = pt.second.targetPackedId;
-                    PetscReal   value = 
-                        ctx->modifier[f][pt.first].coeff * pt.second.a0;
-
-                    ierr = MatSetValue(L, ctx->modifier[f][pt.first].row, 
-                            col, value, ADD_VALUES); CHKERRQ(ierr);
+                    ierr = VecSetValue(y, ctx->modifier[f][pt.first].row,
+                            ctx->modifier[f][pt.first].coeff * pt.second.a1,
+                            ADD_VALUES); CHKERRQ(ierr);
                 }
 
-
-    // assemble matrix, an implicit MPI barrier is applied
-    ierr = MatAssemblyBegin(L, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
-    ierr = MatAssemblyEnd(L, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
-
-
-    // create a matrix-free constraint matrix for boundary correction
-    ierr = MatCreateShell(mesh->comm, mesh->UNLocal, mesh->UNLocal,
-            PETSC_DETERMINE, PETSC_DETERMINE, (void *) ctx, &LCorrection); 
-    CHKERRQ(ierr);
-
-    ierr = MatShellSetOperation(LCorrection, MATOP_MULT,
-            (void(*)(void)) LCorrectionMult); CHKERRQ(ierr);
-
-    ierr = MatShellSetOperation(LCorrection, MATOP_DESTROY,
-            (void(*)(void)) LCorrectionDestroy); CHKERRQ(ierr);
+    // assembly (not sure if this is necessary and if this causes overhead)
+    // but there is an implicit MPI barrier in assembly, which we definitely need
+    ierr = VecAssemblyBegin(y); CHKERRQ(ierr);
+    ierr = VecAssemblyEnd(y); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-} // createLaplacian
+} // LCorrectionMult
 
 
-// implementation of setRowValues
+// a user-defined MatDestroy for constraint mat
+PetscErrorCode LCorrectionDestroy(Mat mat)
+{
+    PetscFunctionBeginUser;
+
+    PetscErrorCode      ierr;
+    LagrangianCtx       *ctx;
+
+    // get the context
+    ierr = MatShellGetContext(mat, (void *) &ctx); CHKERRQ(ierr);
+
+    // deallocate the context
+    delete ctx;
+
+    PetscFunctionReturn(0);
+} // LCorrectionDestroy
+
+
+// a private function that sets values of a row in Laplacian.
+// mesh: an instance of CartesianMesh class.
+// bc: an instance of Boundary class.
+// getStencils: a function that returns stencils according to dim.
+// f: the index of field (u=0, v=1, z=2).
+// i: the x-index of current row in the Cartesian mesh.
+// j: the y-index of current row in the Cartesian mesh.
+// k: the z-index of current row in the Cartesian mesh.
+// L: the Laplacian matrix.
+// rowModifiers: an object holding information about where in a matrix should be modified.
 inline PetscErrorCode setRowValues(
-        const type::Mesh &mesh,
-        const type::Boundary &bc, 
-        const GetStencilsFunc &getStencils, 
-        const PetscInt &f, const PetscInt &i, 
+        const petibm::type::Mesh &mesh,
+        const petibm::type::Boundary &bc,
+        const GetStencilsFunc &getStencils,
+        const PetscInt &f, const PetscInt &i,
         const PetscInt &j, const PetscInt &k, Mat &L,
-        std::map<MatStencil, type::RowModifier> &rowModifiers)
+        std::map<MatStencil, petibm::type::RowModifier> &rowModifiers)
 {
     PetscFunctionBeginUser;
 
@@ -198,9 +119,9 @@ inline PetscErrorCode setRowValues(
 
     StencilVec          stencils = getStencils(i, j, k);
 
-    type::IntVec1D      cols(1+2*mesh->dim, -1);
+    petibm::type::IntVec1D      cols(1+2*mesh->dim, -1);
 
-    type::RealVec1D     values(1+2*mesh->dim, 0.0);
+    petibm::type::RealVec1D     values(1+2*mesh->dim, 0.0);
 
 
     // get the local index for points in stencils
@@ -232,7 +153,7 @@ inline PetscErrorCode setRowValues(
     values[0] = - std::accumulate(values.begin()+1, values.end(), 0.0);
 
     // set the coefficient for the left point
-    ierr = MatSetValues(L, 1, &cols[0], stencils.size(), cols.data(), 
+    ierr = MatSetValues(L, 1, &cols[0], stencils.size(), cols.data(),
             values.data(), INSERT_VALUES); CHKERRQ(ierr);
 
     // save the values for boundary ghost points
@@ -241,59 +162,116 @@ inline PetscErrorCode setRowValues(
 
     PetscFunctionReturn(0);
 } // setRowValues
+} // end of anonymous namespace
 
 
-// implementation of LCorrectionMult
-PetscErrorCode LCorrectionMult(Mat mat, Vec x, Vec y)
+namespace petibm
 {
+namespace operators
+{
+
+// implementation of petibm::operators::createLaplacian
+PetscErrorCode createLaplacian(const type::Mesh &mesh,
+                               const type::Boundary &bc,
+                               Mat &L, Mat &LCorrection)
+{
+    using namespace std::placeholders;
+
     PetscFunctionBeginUser;
 
-    PetscErrorCode      ierr;
+    PetscErrorCode                  ierr;
 
-    LagrangianCtx       *ctx;
+    GetStencilsFunc                 getStencils;
 
-    // get the context
-    ierr = MatShellGetContext(mat, (void *) &ctx); CHKERRQ(ierr);
+    LagrangianCtx                   *ctx;
 
-    // zero the output vector
-    ierr = VecSet(y, 0.0); CHKERRQ(ierr);
 
-    // set the correction values to corresponding rows
-    for(PetscInt f=0; f<ctx->bc->dim; ++f)
-        for(auto &bd: ctx->bc->bds[f])
+    // initialize modifier, regardless what's inside it now
+    ctx = new LagrangianCtx(bc);
+
+    // set up getStencils
+    if (mesh->dim == 2)
+        getStencils =
+            [](const PetscInt &i, const PetscInt &j, const PetscInt &k)
+            -> StencilVec {
+                return {{k, j, i, 0},
+                        {k, j, i-1, 0}, {k, j, i+1, 0},
+                        {k, j-1, i, 0}, {k, j+1, i, 0}};
+            };
+    else // implies dim == 3
+        getStencils =
+            [](const PetscInt &i, const PetscInt &j, const PetscInt &k)
+            -> StencilVec {
+                return {{k, j, i, 0},
+                        {k, j, i-1, 0}, {k, j, i+1, 0},
+                        {k, j-1, i, 0}, {k, j+1, i, 0},
+                        {k-1, j, i, 0}, {k+1, j, i, 0}};
+            };
+
+
+    // create matrix
+    ierr = DMCreateMatrix(mesh->UPack, &L); CHKERRQ(ierr);
+    ierr = MatSetFromOptions(L); CHKERRQ(ierr);
+    ierr = MatSetOption(L, MAT_KEEP_NONZERO_PATTERN, PETSC_FALSE); CHKERRQ(ierr);
+    ierr = MatSetOption(L, MAT_IGNORE_ZERO_ENTRIES, PETSC_TRUE); CHKERRQ(ierr);
+
+
+    // set values, one field each time
+    for(PetscInt field=0; field<mesh->dim; ++field)
+    {
+        // set row values
+        // the std::bind originally only binds values, in order to use
+        // reference instead of value-copying, we have to use std::ref
+        ierr = misc::tripleLoops(
+                {mesh->bg[field][2], mesh->ed[field][2]},
+                {mesh->bg[field][1], mesh->ed[field][1]},
+                {mesh->bg[field][0], mesh->ed[field][0]},
+                std::bind(setRowValues,
+                    std::ref(mesh), std::ref(bc), std::ref(getStencils),
+                    std::ref(field), _3, _2, _1, std::ref(L),
+                    std::ref(ctx->modifier[field])));
+        CHKERRQ(ierr);
+    }
+
+
+    // temporarily assemble matrix
+    ierr = MatAssemblyBegin(L, MAT_FLUSH_ASSEMBLY); CHKERRQ(ierr);
+    ierr = MatAssemblyEnd(L, MAT_FLUSH_ASSEMBLY); CHKERRQ(ierr);
+
+
+    // TODO: check if a0 coefficients are already up-to-date.
+    for(PetscInt f=0; f<mesh->dim; ++f)
+        for(auto &bd: bc->bds[f])
             if (bd->onThisProc)
                 for(auto &pt: bd->points)
                 {
-                    ierr = VecSetValue(y, ctx->modifier[f][pt.first].row,
-                            ctx->modifier[f][pt.first].coeff * pt.second.a1, 
-                            ADD_VALUES); CHKERRQ(ierr);
+                    PetscInt    col = pt.second.targetPackedId;
+                    PetscReal   value =
+                        ctx->modifier[f][pt.first].coeff * pt.second.a0;
+
+                    ierr = MatSetValue(L, ctx->modifier[f][pt.first].row,
+                            col, value, ADD_VALUES); CHKERRQ(ierr);
                 }
 
-    // assembly (not sure if this is necessary and if this causes overhead)
-    // but there is an implicit MPI barrier in assembly, which we definitely need
-    ierr = VecAssemblyBegin(y); CHKERRQ(ierr);
-    ierr = VecAssemblyEnd(y); CHKERRQ(ierr);
+
+    // assemble matrix, an implicit MPI barrier is applied
+    ierr = MatAssemblyBegin(L, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+    ierr = MatAssemblyEnd(L, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
+
+
+    // create a matrix-free constraint matrix for boundary correction
+    ierr = MatCreateShell(mesh->comm, mesh->UNLocal, mesh->UNLocal,
+            PETSC_DETERMINE, PETSC_DETERMINE, (void *) ctx, &LCorrection);
+    CHKERRQ(ierr);
+
+    ierr = MatShellSetOperation(LCorrection, MATOP_MULT,
+            (void(*)(void)) LCorrectionMult); CHKERRQ(ierr);
+
+    ierr = MatShellSetOperation(LCorrection, MATOP_DESTROY,
+            (void(*)(void)) LCorrectionDestroy); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-} // LCorrectionMult
-
-
-// implementation of LCorrectionDestroy
-PetscErrorCode LCorrectionDestroy(Mat mat)
-{
-    PetscFunctionBeginUser;
-
-    PetscErrorCode      ierr;
-    LagrangianCtx       *ctx;
-
-    // get the context
-    ierr = MatShellGetContext(mat, (void *) &ctx); CHKERRQ(ierr);
-
-    // deallocate the context
-    delete ctx;
-
-    PetscFunctionReturn(0);
-} // LCorrectionDestroy
+} // createLaplacian
 
 } // end of namespace operators
 } // end of namespace petibm

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -118,7 +118,7 @@ PetscErrorCode checkAndCreateFolder(const std::string &dir)
 
     PetscFunctionReturn(0);
 } // checkAndCreateFolder
-}
+} // end of anonymous namespace
 
 
 namespace petibm


### PR DESCRIPTION
Encapsulating local functions in an anonymous namespace to apply local linkage. This will prevent API users from linking these local & private functions accidentally.