### PR TITLE
Fix bug in volume probe and allow multiple BN orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### Added
 
+* Add possibility to choose the order of the truncated Taylor series expansion for the inverse of the implicit operator. The order can be set in the YAML configuration file using the key `BN` under the YAML node `parameters`. (The default value is `BN: 1`.)
+
 ### Changed
+
+* Use `-pc_factor_mat_solver_type` instead of `-pc_factor_mat_solver_package` in the configuration files for the forces solver. (This removes the deprecation warning when using PETSc-3.9+.)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Currently, two immersed boundary methods are implemented:
 * Immersed Boundary Projection Method (IBPM; Taira and Colonius, 2007);
 * decoupled version of the IBPM (Li et al., 2016).
 
-With object-oriented design, the objects and classes in PetIBM can be re-used to develop other solvers easily, as long as the numerical methods used can fit into Perot's framework (Perot, 1993; Chang et. al, 2002). 
+With object-oriented design, the objects and classes in PetIBM can be re-used to develop other solvers easily, as long as the numerical methods used can fit into Perot's framework (Perot, 1993; Chang et. al, 2002).
 See [Doxygen pages](https://barbagroup.github.io/PetIBM/modules.html) for API manual.
 
-PetIBM relies on the [PETSc](http://www.mcs.anl.gov/petsc/) library for data structures and parallel routines. 
+PetIBM relies on the [PETSc](http://www.mcs.anl.gov/petsc/) library for data structures and parallel routines.
 Linear systems can be solved either on CPUs using PETSc KSP objects or on multiple CUDA-capable GPU devices using the NVIDIA [AmgX](https://github.com/NVIDIA/AMGX) library.
 Data transfers between PETSc and AmgX are handled by [AmgXWrapper](https://github.com/barbagroup/AmgXWrapper).
 
@@ -30,6 +30,7 @@ Please see [Documentation](#documentation) for more details.
 ## Features
 
 PetIBM supports:
+
 * multiple immersed bodies,
 * moving bodies with prescribed kinematics,
 * 2D and 3D stretched Cartesian meshes,
@@ -38,19 +39,18 @@ PetIBM supports:
 * GPU clusters, and
 * HDF5 I/O.
 
-
 ---
 
 ## Documentation
 
 * [Quick Start](doc/markdowns)
-    * [Dependencies and Installation](doc/markdowns/installation.md)
-    * [Run PetIBM](doc/markdowns/runpetibm.md)
-    * [Input files](doc/markdowns/inputs.md)
-    * [Output files](doc/markdowns/outputs.md)
-    * [2D Examples](doc/markdowns/examples2d.md)
-    * [3D Examples](doc/markdowns/examples3d.md)
-    * [Use PetIBM API](doc/markdowns/usepetibmapi.md)
+  * [Dependencies and Installation](doc/markdowns/installation.md)
+  * [Run PetIBM](doc/markdowns/runpetibm.md)
+  * [Input files](doc/markdowns/inputs.md)
+  * [Output files](doc/markdowns/outputs.md)
+  * [2D Examples](doc/markdowns/examples2d.md)
+  * [3D Examples](doc/markdowns/examples3d.md)
+  * [Use PetIBM API](doc/markdowns/usepetibmapi.md)
 * [Online API manual](https://barbagroup.github.io/PetIBM)
 * [Change Log](CHANGELOG.md)
 * [Contributing](CONTRIBUTING.md)
@@ -62,7 +62,6 @@ Offline API manual can be generated with [Doxygen](http://www.stack.nl/~dimitri/
 ## Papers published using PetIBM
 
 * Mesnard, O., & Barba, L. A. (2017). _Reproducible and Replicable Computational Fluid Dynamics: It's Harder Than You Think_. Computing in Science & Engineering, 19(4), 44-55, https://doi.org/10.1109/MCSE.2017.3151254.
-
 
 ---
 
@@ -89,9 +88,7 @@ We are also open to pull-requests.
 If PetIBM contributes to a project that leads to a scientific publication, please cite the project.
 You can use this citation or the BibTeX entry below.
 
-### PetIBM - toolbox and applications of the immersed-boundary method on distributed-memory architectures
-
-> Pi-Yueh Chuang, Olivier Mesnard, Anush Krishnan, Lorena A. Barba (2018). PetIBM: toolbox and applications of the immersed-boundary method on distributed-memory architectures. _Journal of Open Source Software_, **3**(25), 558, [doi:10.21105/joss.00558](https://doi.org/10.21105/joss.00558) 
+> Pi-Yueh Chuang, Olivier Mesnard, Anush Krishnan, Lorena A. Barba (2018). PetIBM: toolbox and applications of the immersed-boundary method on distributed-memory architectures. _Journal of Open Source Software_, **3**(25), 558, [doi:10.21105/joss.00558](https://doi.org/10.21105/joss.00558)
 
 ```console
 @article{chuang2018petibm,

--- a/applications/decoupledibpm/decoupledibpm.cpp
+++ b/applications/decoupledibpm/decoupledibpm.cpp
@@ -192,8 +192,10 @@ PetscErrorCode DecoupledIBPMSolver::createExtraOperators()
     // size of the Eulerian grid near by.
 
     // create the operator BN
+    PetscInt N;  // order of the truncate Taylor series expansion
+    N = config["parameters"]["BN"].as<PetscInt>(1);
     ierr = petibm::operators::createBnHead(
-        L, dt, diffCoeffs->implicitCoeff * nu, 1, BN); CHKERRQ(ierr);
+        L, dt, diffCoeffs->implicitCoeff * nu, N, BN); CHKERRQ(ierr);
 
     // create the operator BNH
     ierr = MatMatMult(

--- a/applications/ibpm/ibpm.cpp
+++ b/applications/ibpm/ibpm.cpp
@@ -182,8 +182,10 @@ PetscErrorCode IBPMSolver::createOperators()
     ierr = MatDestroy(&DE[1]); CHKERRQ(ierr);
 
     // create the projection operator: BNG
+    PetscInt N;  // order of the truncate Taylor series expansion
+    N = config["parameters"]["BN"].as<PetscInt>(1);
     ierr = petibm::operators::createBnHead(
-        L, dt, diffCoeffs->implicitCoeff * nu, 1, BN); CHKERRQ(ierr);
+        L, dt, diffCoeffs->implicitCoeff * nu, N, BN); CHKERRQ(ierr);
     ierr = MatMatMult(
         BN, G, MAT_INITIAL_MATRIX, PETSC_DEFAULT, &BNG); CHKERRQ(ierr);
 

--- a/applications/navierstokes/navierstokes.cpp
+++ b/applications/navierstokes/navierstokes.cpp
@@ -339,8 +339,10 @@ PetscErrorCode NavierStokesSolver::createOperators()
     ierr = MatShift(A, 1.0 / dt); CHKERRQ(ierr);
 
     // create the projection operator: BNG
+    PetscInt N;  // order of the truncate Taylor series expansion
+    N = config["parameters"]["BN"].as<PetscInt>(1);
     ierr = petibm::operators::createBnHead(
-        L, dt, diffCoeffs->implicitCoeff * nu, 1, BN); CHKERRQ(ierr);
+        L, dt, diffCoeffs->implicitCoeff * nu, N, BN); CHKERRQ(ierr);
     ierr = MatMatMult(
         BN, G, MAT_INITIAL_MATRIX, PETSC_DEFAULT, &BNG); CHKERRQ(ierr);
 

--- a/doc/markdowns/inputs.md
+++ b/doc/markdowns/inputs.md
@@ -193,6 +193,7 @@ This node gather various `parameters` regarding the advancement of a simulation.
 - `nrestart`: frequency (in number of time steps) of saving for the convective and diffusive terms; those terms will required upon restart of a run at a time step different from 0.
 - `convection`: time scheme for the convective terms; choices are the default explicit Euler method (`EULER_EXPLICIT`) or an explicit second-order Adams-Bashforth scheme (`ADAMS_BASHFORTH_2`).
 - `diffusion`: time scheme for the diffusive terms; choices are the default implicit Euler method (`EULER_IMPLICIT`), an explicit Euler method (`EULER_EXPLICIT`), or a second-order Crank-Nicolson scheme (`CRANK_NICOLSON`).
+- `BN`: order of the truncated Taylor series expansion of the implicit matrix `A` (where `A` is the left-hand side operator of the system for the intermediate velocity vector). The default value is `1`, which leads to the identity operator scaled by the time-step size.
 - `delta`: regularized delta function to use; choices are `ROMA_ET_AL_1999` (3-point kernel) and `PESKIN_2002` (4-point kernel).
 - `velocitySolver`, `poissonSolver`, and `forcesSolver` (for the decoupled version of the immersed-boundary projection method) each references the type of hardware used to solve the linear system (either `CPU` or `GPU`) and the path (relative to the YAML configuration file) of the file containing the parameters for the linear solver.
 
@@ -207,6 +208,7 @@ parameters:
     nrestart: 200
     convection: ADAMS_BASHFORTH_2
     diffusion: CRANK_NICOLSON
+    BN: 1
     velocitySolver:
       type: CPU
       config: solversPetscOptions.info

--- a/doc/markdowns/installation.md
+++ b/doc/markdowns/installation.md
@@ -4,32 +4,32 @@
 
 **Required**:
 
-* GNU C++ compiler g++: v4.9.2, v5.4.0, and v7.2.1 have been tested
-* [PETSc](https://www.mcs.anl.gov/petsc/): v3.8.1 or above; with HDF5 enabled
-* MPI: OpenMPI, MPICH, and Intel MPI have been tested
-* [yaml-cpp](https://github.com/jbeder/yaml-cpp)
-* [gtest](https://github.com/google/googletest)
+* GNU C++ compiler g++ (4.9.2, 5.4.0, and 7.2.1 have been tested)
+* [PETSc](https://www.mcs.anl.gov/petsc/) (3.8+) with HDF5 enabled
+* MPI: OpenMPI, MPICH, or Intel MPI
+* [yaml-cpp](https://github.com/jbeder/yaml-cpp) (0.6.2)
+* [gtest](https://github.com/google/googletest) (1.7.0)
 
 **Optional for GPU linear solvers**:
 
-* [AmgX](https://github.com/NVIDIA/AMGX)
-* [AmgXWrapper](https://github.com/barbagroup/AmgXWrapper) (v1.3)
+* [AmgX](https://github.com/NVIDIA/AMGX) (2.0.0.130-opensource)
+* [AmgXWrapper](https://github.com/barbagroup/AmgXWrapper) (1.4)
 
-**Optional for pre- and post-processing scripts**:
+**Optional for pre- and post-processing Python scripts**:
 
-* Python (3.6)
-* Numpy (1.12.1)
-* H5py (2.7.0)
+* Python (3.6+)
+* NumPy (1.12.1)
+* h5py (2.7.0)
 * Matplotlib (2.0.2)
 
 **Note**:
 
 * MPI can be either installed during [PETSc configuration](#petsc) or installed explicitly by users.
-* [yaml-cpp](https://github.com/jbeder/yaml-cpp), 
-  [gtest](https://github.com/google/googletest), and 
+* [yaml-cpp](https://github.com/jbeder/yaml-cpp),
+  [gtest](https://github.com/google/googletest), and
   [AmgXWrapper](https://github.com/barbagroup/AmgXWrapper) can be automatically installed during PetIBM configuration or explicitly installed by users in advance.
 * PetIBM has been tested on:
-    * Ubuntu 16.04 with g++-5.4, and PETSc-3.8.1
+    * Ubuntu 16.04 with g++-5.4, and PETSc-3.11.2
     * MacOS Sierra with g++-6.0, and PETSc-3.8.2
     * Arch Linux with g++-7.2, and PETSc-3.8.2
 * PetIBM has also been tested on the following HPC systems:
@@ -56,68 +56,94 @@ On Mac OS X, `g++` can be installed on Mac OS X via XCode or [Homebrew](brew.sh)
 
 PetIBM relies on the data structures and parallel routines of the PETSc library.
 
-Install PETSc-3.8 in debugging mode and/or optimized mode.
+Here, we provide the command-line instructions to install PETSc-3.11.3 in debugging mode and/or optimized mode.
 The debug mode is recommended during development, while the optimized mode should be used for production runs.
 
 Get and unpack PETSc:
 
-    cd $HOME/sfw
-    mkdir -p petsc/3.8.1
-    wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.8.1.tar.gz
-    tar -xvf petsc-lite-3.8.1.tar.gz -C petsc/3.8.1 --strip-components=1
-    cd petsc/3.8.1
+```shell
+cd $HOME/sfw
+mkdir -p petsc/3.11.3
+wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.11.3.tar.gz
+tar -xvf petsc-lite-3.11.3.tar.gz -C petsc/3.11.3 --strip-components=1
+cd petsc/3.11.3
+```
 
 Configure and build an debugging version of PETSc:
 
-    export PETSC_DIR=$HOME/sfw/petsc/3.8.1
-    export PETSC_ARCH=linux-dbg
-    ./configure --PETSC_DIR=$PETSC_DIR --PETSC_ARCH=$PETSC_ARCH \
-        --with-cc=gcc \
-        --with-cxx=g++ \
-        --with-fc=gfortran \
-        --COPTFLAGS="-O0" \
-        --CXXOPTFLAGS="-O0" \
-        --FOPTFLAGS="-O0" \
-        --with-debugging=1 \
-        --download-fblaslapack \
-        --download-openmpi \
-        --download-hdf5
-    make all
-    make test
+```shell
+export PETSC_DIR=$HOME/sfw/petsc/3.11.3
+export PETSC_ARCH=linux-dbg
+./configure --PETSC_DIR=$PETSC_DIR --PETSC_ARCH=$PETSC_ARCH \
+    --with-cc=gcc \
+    --with-cxx=g++ \
+    --with-fc=gfortran \
+    --COPTFLAGS="-O0" \
+    --CXXOPTFLAGS="-O0" \
+    --FOPTFLAGS="-O0" \
+    --with-debugging=1 \
+    --download-fblaslapack \
+    --download-openmpi \
+    --download-hdf5 \
+    --download-hypre \
+    --download-ptscotch \
+    --download-metis \
+    --download-parmetis \
+    --download-superlu_dist
+make all
+make test
+```
 
 If you do not have a Fortran compiler ready, you use the following configuration:
 
-    ./configure --PETSC_ARCH=$PETSC_ARCH \
-        --with-cc=gcc \
-        --with-cxx=g++ \
-        --COPTFLAGS="-O0" \
-        --CXXOPTFLAGS="-O0" \
-        --with-debugging=1 \
-        --download-f2cblaslapack \
-        --download-openmpi \
-        --download-hdf5
+```shell
+./configure --PETSC_ARCH=$PETSC_ARCH \
+    --with-cc=gcc \
+    --with-cxx=g++ \
+    --COPTFLAGS="-O0" \
+    --CXXOPTFLAGS="-O0" \
+    --with-debugging=1 \
+    --download-f2cblaslapack \
+    --download-openmpi \
+    --download-hdf5 \
+    --download-hypre \
+    --download-ptscotch \
+    --download-metis \
+    --download-parmetis \
+    --download-superlu_dist
+```
 
 Configure and build an optimized version of PETSc:
 
-    export PETSC_DIR=$HOME/sfw/petsc/3.8.1
-    export PETSC_ARCH=linux-opt
-    ./configure --PETSC_DIR=$PETSC_DIR --PETSC_ARCH=$PETSC_ARCH \
-        --with-cc=gcc \
-        --with-cxx=g++ \
-        --with-fc=gfortran \
-        --COPTFLAGS="-O3" \
-        --CXXOPTFLAGS="-O3" \
-        --FOPTFLAGS="-O3" \
-        --with-debugging=0 \
-        --download-fblaslapack \
-        --download-openmpi \
-        --download-hdf5
-    make all
-    make test
+```shell
+export PETSC_DIR=$HOME/sfw/petsc/3.11.3
+export PETSC_ARCH=linux-opt
+./configure --PETSC_DIR=$PETSC_DIR --PETSC_ARCH=$PETSC_ARCH \
+    --with-cc=gcc \
+    --with-cxx=g++ \
+    --with-fc=gfortran \
+    --COPTFLAGS="-O3" \
+    --CXXOPTFLAGS="-O3" \
+    --FOPTFLAGS="-O3" \
+    --with-debugging=0 \
+    --download-fblaslapack \
+    --download-openmpi \
+    --download-hdf5 \
+    --download-hypre \
+    --download-ptscotch \
+    --download-metis \
+    --download-parmetis \
+    --download-superlu_dist
+make all
+make test
+```
 
-When running the code on an external cluster, make sure that you compile PETSc with the MPI that has been configured to work with the cluster. Hence, **do not use the `--download-openmpi` flag**, but instead point to the folder with the MPI compilers and executables using the `--with-mpi-dir` flag. If BLAS and LAPACK are already installed in the system, you can point to the libraries using the `--with-blas-lib` and `--with-lapack-lib` flags.
+When running the code on an external cluster, make sure that you compile PETSc with the MPI that has been configured to work with the cluster.
+Hence, **do not use the `--download-openmpi` flag**, but instead point to the folder with the MPI compilers and executables using the `--with-mpi-dir` flag.
+If BLAS and LAPACK are already installed in the system, you can point to the libraries using the `--with-blas-lib` and `--with-lapack-lib` flags.
 
-[Detailed instructions](http://www.mcs.anl.gov/petsc/documentation/installation.html) with more options to customize your installation can be found on the PETSc website. Run `./configure --help` in the PETSc root directory to list all the available configure flags.
+[Detailed instructions](http://www.mcs.anl.gov/petsc/documentation/installation.html) with more options to customize your installation can be found on the PETSc website.
+Run `./configure --help` in the PETSc root directory to list all the available configure flags.
 
 The PETSc Users Manual and the Manual Pages can be found on their
 [documentation page](http://www.mcs.anl.gov/petsc/documentation/index.html).
@@ -126,7 +152,7 @@ The PETSc Users Manual and the Manual Pages can be found on their
 
 ## yaml-cpp
 
-[yaml-cpp](https://github.com/jbeder/yaml-cpp) is a YAML parser in C++ used in PetIBM to parse the input configuration file.
+[yaml-cpp](https://github.com/jbeder/yaml-cpp) is a YAML parser in C++, used in PetIBM to parse the input configuration file.
 
 The PetIBM configuration script gives the possibility to use a previously installed version of yaml-cpp (with the configuration argument `--with-yamlcpp-dir=<path>`, or `--with-yamlcpp-include=<path>` and `--with-yamlcpp-lib=<path>`) or to download and install yaml-cpp-0.6.2 (with `--enable-yamlcpp`).
 
@@ -143,69 +169,82 @@ When configuring PetIBM, you can either use a previously installed version of gt
 
 Create a local copy of the PetIBM repository:
 
-    cd $HOME/sfw
-    mkdir petibm && cd petibm
-    git clone https://github.com/barbagroup/PetIBM.git
-    export PETIBM_DIR=$HOME/sfw/petibm/PetIBM
+```shell
+cd $HOME/sfw
+mkdir petibm && cd petibm
+git clone https://github.com/barbagroup/PetIBM.git
+export PETIBM_DIR=$HOME/sfw/petibm/PetIBM
+```
 
 You can set the environment variable `PETIBM_DIR` to your `$HOME/.bashrc` or `$HOME/.bash_profile` files by adding the line:
 
-    export PETIBM_DIR=$HOME/sfw/petibm/PetIBM
+```shell
+export PETIBM_DIR=$HOME/sfw/petibm/PetIBM
+```
 
-and restart you terminal or  source the file:
+and restart you terminal or source the file:
 
-    source $HOME/.bashrc
+```shell
+source $HOME/.bashrc
+```
 
 Note: if you are using C shell, use the `setenv` command instead of `export`.
 
 Configure and build PetIBM with PETSc in debugging mode:
 
-    PETSC_DIR=$HOME/sfw/petsc/3.8.1
-    PETSC_ARCH=linux-dbg
-    mkdir petibm-linux-dbg && cd petibm-linux-dbg
-    $PETIBM_DIR/configure \
-        --prefix=$HOME/sfw/petibm/petibm-linux-dbg \
-        CXX=$PETSC_DIR/$PETSC_ARCH/bin/mpicxx \
-        CXXFLAGS="-g -O0 -Wall -Wno-deprecated -std=c++14" \
-        --with-petsc-dir=$PETSC_DIR \
-        --with-petsc-arch=$PETSC_ARCH \
-        --with-yamlcpp-dir=<path> \
-        --with-gtest-dir=<path>
-    make all
-    make check
-    make install
+```shell
+PETSC_DIR=$HOME/sfw/petsc/3.11.3
+PETSC_ARCH=linux-dbg
+mkdir petibm-linux-dbg && cd petibm-linux-dbg
+$PETIBM_DIR/configure \
+    --prefix=$HOME/sfw/petibm/petibm-linux-dbg \
+    CXX=$PETSC_DIR/$PETSC_ARCH/bin/mpicxx \
+    CXXFLAGS="-g -O0 -Wall -Wno-deprecated -std=c++14" \
+    --with-petsc-dir=$PETSC_DIR \
+    --with-petsc-arch=$PETSC_ARCH \
+    --with-yamlcpp-dir=<path> \
+    --with-gtest-dir=<path>
+make all
+make check
+make install
+```
 
 If yaml-cpp and/or gtest are not available, you can request installation at configuration time using:
 
-    $PETIBM_DIR/configure \
-        --prefix=$HOME/sfw/petibm/petibm-linux-dbg \
-        CXX=$PETSC_DIR/$PETSC_ARCH/bin/mpicxx \
-        CXXFLAGS="-g -O0 -Wall -Wno-deprecated -std=c++14" \
-        --enable-yamlcpp \
-        --enable-gtest
+```shell
+$PETIBM_DIR/configure \
+    --prefix=$HOME/sfw/petibm/petibm-linux-dbg \
+    CXX=$PETSC_DIR/$PETSC_ARCH/bin/mpicxx \
+    CXXFLAGS="-g -O0 -Wall -Wno-deprecated -std=c++14" \
+    --enable-yamlcpp \
+    --enable-gtest
+```
 
 For production runs, you may want to use the optimized build of PETSc:
 
-You may also want to build a optimized version:
+```shell
+PETSC_DIR=$HOME/sfw/petsc/3.11.3
+PETSC_ARCH=linux-opt
+mkdir petibm-linux-opt && cd petibm-linux-opt
+$PETIBM_DIR/configure \
+    --prefix=$HOME/sfw/petibm/petibm-linux-opt \
+    CXX=$PETSC_DIR/$PETSC_ARCH/bin/mpicxx \
+    CXXFLAGS="-O3 -Wall -Wno-deprecated -std=c++14" \
+    --with-petsc-dir=$PETSC_DIR \
+    --with-petsc-arch=$PETSC_ARCH \
+    --with-yamlcpp-dir=<path> \
+    --with-gtest-dir=<path>
+make all
+make check
+make install
+```
 
-    PETSC_DIR=$HOME/sfw/petsc/3.8.1
-    PETSC_ARCH=linux-opt
-    mkdir petibm-linux-opt && cd petibm-linux-opt
-    $PETIBM_DIR/configure \
-        --prefix=$HOME/sfw/petibm/petibm-linux-opt \
-        CXX=$PETSC_DIR/$PETSC_ARCH/bin/mpicxx \
-        CXXFLAGS="-O3 -Wall -Wno-deprecated -std=c++14" \
-        --with-petsc-dir=$PETSC_DIR \
-        --with-petsc-arch=$PETSC_ARCH \
-        --with-yamlcpp-dir=<path> \
-        --with-gtest-dir=<path>
-    make all
-    make check
-    make install
+Et voila!
+You can now add the `bin` directory (that contains the executables) to you PATH environment variable:
 
-Et voila! You can now add the `bin` directory (that contains the executables) to you PATH environment variable:
-
-    export PATH=$HOME/sfw/petibm/petibm-linux-opt/bin:$PATH
+```shell
+export PATH=$HOME/sfw/petibm/petibm-linux-opt/bin:$PATH
+```
 
 ---
 
@@ -214,7 +253,9 @@ Et voila! You can now add the `bin` directory (that contains the executables) to
 We provide some examples!
 Input files are located in `$PETIBM_DIR`, but can be copied to another directory with
 
-    make copy-examples EXAMPLES_DIR=<directory>
+```shell
+make copy-examples EXAMPLES_DIR=<directory>
+```
 
 `EXAMPLES_DIR` is optional and the default directory is the folder `examples` in the top build directory.
 
@@ -231,23 +272,25 @@ When configuring PetIBM, you can either use a previously installed version of Am
 
 For example, to build an optimized version of PetIBM with CUDA, AmgX, and AmgXWrapper:
 
-    PETSC_DIR=$HOME/sfw/petsc/3.8.1
-    PETSC_ARCH=linux-opt
-    mkdir petibm-linux-opt && cd petibm-linux-opt
-    $PETIBM_DIR/configure \
-        --prefix=$HOME/sfw/petibm/petibm-linux-opt \
-        CXX=$PETSC_DIR/$PETSC_ARCH/bin/mpicxx \
-        CXXFLAGS="-O3 -Wall -Wno-deprecated -std=c++14" \
-        --with-petsc-dir=$PETSC_DIR \
-        --with-petsc-arch=$PETSC_ARCH \
-        --with-yamlcpp-dir=<path> \
-        --with-gtest-dir=<path> \
-        --with-cuda-dir=<path> \
-        --with-amgx-dir=<path> \
-        --with-amgxwrapper-dir=<path>
-    make all
-    make check
-    make install
+```shell
+PETSC_DIR=$HOME/sfw/petsc/3.11.3
+PETSC_ARCH=linux-opt
+mkdir petibm-linux-opt && cd petibm-linux-opt
+$PETIBM_DIR/configure \
+    --prefix=$HOME/sfw/petibm/petibm-linux-opt \
+    CXX=$PETSC_DIR/$PETSC_ARCH/bin/mpicxx \
+    CXXFLAGS="-O3 -Wall -Wno-deprecated -std=c++14" \
+    --with-petsc-dir=$PETSC_DIR \
+    --with-petsc-arch=$PETSC_ARCH \
+    --with-yamlcpp-dir=<path> \
+    --with-gtest-dir=<path> \
+    --with-cuda-dir=<path> \
+    --with-amgx-dir=<path> \
+    --with-amgxwrapper-dir=<path>
+make all
+make check
+make install
+```
 
 ---
 

--- a/examples/api_examples/oscillatingcylinder2dRe100_GPU/config/forces_solver.info
+++ b/examples/api_examples/oscillatingcylinder2dRe100_GPU/config/forces_solver.info
@@ -1,4 +1,4 @@
 # forces solver: prefix `-forces_`
 -forces_ksp_type preonly
 -forces_pc_type lu
--forces_pc_factor_mat_solver_package superlu_dist
+-forces_pc_factor_mat_solver_type superlu_dist

--- a/examples/decoupledibpm/cylinder2dRe100_GPU/config/forces_solver.info
+++ b/examples/decoupledibpm/cylinder2dRe100_GPU/config/forces_solver.info
@@ -1,4 +1,4 @@
 # forces solver: prefix `-forces_`
 -forces_ksp_type preonly
 -forces_pc_type lu
--forces_pc_factor_mat_solver_package superlu_dist
+-forces_pc_factor_mat_solver_type superlu_dist

--- a/examples/decoupledibpm/cylinder2dRe3000_GPU/config/forces_solver.info
+++ b/examples/decoupledibpm/cylinder2dRe3000_GPU/config/forces_solver.info
@@ -1,4 +1,4 @@
 # forces solver: prefix `-forces_`
 -forces_ksp_type preonly
 -forces_pc_type lu
--forces_pc_factor_mat_solver_package superlu_dist
+-forces_pc_factor_mat_solver_type superlu_dist

--- a/examples/decoupledibpm/cylinder2dRe40_GPU/config/forces_solver.info
+++ b/examples/decoupledibpm/cylinder2dRe40_GPU/config/forces_solver.info
@@ -1,4 +1,4 @@
 # forces solver: prefix `-forces_`
 -forces_ksp_type preonly
 -forces_pc_type lu
--forces_pc_factor_mat_solver_package superlu_dist
+-forces_pc_factor_mat_solver_type superlu_dist

--- a/examples/decoupledibpm/cylinder2dRe550_GPU/config/forces_solver.info
+++ b/examples/decoupledibpm/cylinder2dRe550_GPU/config/forces_solver.info
@@ -1,4 +1,4 @@
 # forces solver: prefix `-forces_`
 -forces_ksp_type preonly
 -forces_pc_type lu
--forces_pc_factor_mat_solver_package superlu_dist
+-forces_pc_factor_mat_solver_type superlu_dist

--- a/examples/decoupledibpm/flatplate3dRe100AoA30_GPU/config/forces_solver.info
+++ b/examples/decoupledibpm/flatplate3dRe100AoA30_GPU/config/forces_solver.info
@@ -1,4 +1,4 @@
 # forces solver: prefix `-forces_`
 -forces_ksp_type preonly
 -forces_pc_type lu
--forces_pc_factor_mat_solver_package superlu_dist
+-forces_pc_factor_mat_solver_type superlu_dist

--- a/examples/decoupledibpm/flatplate3dRe100_GPU/config/forces_solver.info
+++ b/examples/decoupledibpm/flatplate3dRe100_GPU/config/forces_solver.info
@@ -1,4 +1,4 @@
 # forces solver: prefix `-forces_`
 -forces_ksp_type preonly
 -forces_pc_type lu
--forces_pc_factor_mat_solver_package superlu_dist
+-forces_pc_factor_mat_solver_type superlu_dist

--- a/examples/decoupledibpm/multicylinders2dRe100_GPU/config/forces_solver.info
+++ b/examples/decoupledibpm/multicylinders2dRe100_GPU/config/forces_solver.info
@@ -1,4 +1,4 @@
 # forces solver: prefix `-forces_`
 -forces_ksp_type preonly
 -forces_pc_type lu
--forces_pc_factor_mat_solver_package superlu_dist
+-forces_pc_factor_mat_solver_type superlu_dist

--- a/scripts/travis-install-petsc.sh
+++ b/scripts/travis-install-petsc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Install PETSc-3.8.2 in debug mode.
+# Install PETSc-3.11.3 in debug mode.
 # Use the cached PETSc if mpicxx is detected.
 
 PETSC_DIR=$1
@@ -17,8 +17,8 @@ if [ -f "$PETSC_DIR/$PETSC_ARCH/bin/mpicxx" ]; then
     --download-f2cblaslapack --download-hdf5 --download-openmpi
 else
   echo "Downloading PETSc"
-  URL="http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.8.2.tar.gz"
-  TARBALL=/tmp/petsc-lite-3.8.2.tar.gz
+  URL="http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.11.3.tar.gz"
+  TARBALL=/tmp/petsc-lite-3.11.3.tar.gz
   wget $URL -O $TARBALL
   tar xfz $TARBALL -C $PETSC_DIR --strip-components=1
   rm -f $TARBALL

--- a/src/misc/delta.cpp
+++ b/src/misc/delta.cpp
@@ -29,18 +29,13 @@ PetscReal Roma_et_al_1999(const PetscReal &r, const PetscReal &dr)
 // Regularized delta function Peskin (2002).
 PetscReal Peskin_2002(const PetscReal &r, const PetscReal &dr)
 {
-    PetscReal x = r / dr;
+    PetscReal x = std::abs(r) / dr;
 
-    if (x >= -2.0 && x <= -1.0)
-        return (5 + 2 * x - std::sqrt(-7 - 12 * x - 4 * x * x)) / (8 * dr);
-    else if (x >= -1.0 && x <= 0.0)
-        return (3 + 2 * x + std::sqrt(1 - 4 * x - 4 * x * x)) / (8 * dr);
-    else if (x >= 0.0 && x <= 1.0)
+    if (x >= 0.0 && x <= 1.0)
         return (3 - 2 * x + std::sqrt(1 + 4 * x - 4 * x * x)) / (8 * dr);
     else if (x >= 1.0 && x <= 2.0)
         return (5 - 2 * x - std::sqrt(-7 + 12 * x - 4 * x * x)) / (8 * dr);
-    else
-        return 0.0;
+    return 0.0;
 }  // Peskin_2002
 
 // Get the delta kernel and size to use

--- a/src/misc/probes.cpp
+++ b/src/misc/probes.cpp
@@ -134,7 +134,7 @@ PetscErrorCode ProbeBase::monitor(const type::Solution &solution,
                                                 mesh->dim, nullptr,
                                                 vel.data()); CHKERRQ(ierr);
         }
-        else if (field == 4)  // monitor the pressure field
+        else if (field == 3)  // monitor the pressure field
         {
             ierr = monitorVec(mesh->da[3], solution->pGlobal , n, t); CHKERRQ(ierr);
         }


### PR DESCRIPTION
Fixed:

* There was a bug for the pressure field index when trying the monitor the pressure field with a volume probe.

Added:

* Add possibility to choose (from the YAML configuration file) the order of the approximate inverse `BN` of the implicit velocity operator (left-hand side operator of the system for the intermediate velocity).

Changed:

* Update documentation and README with the new YAML parameter `BN`.
* Update configuration file for the forces solver, in the examples, to remove the deprecation warning from PETSc (use `-pc_factor_mat_solver_type` instead of `-pc_factor_mat_solver_package`).
* Simplify kernel for the regularized delta function of Peskin (2002) because it is a symmetric function.

Ready for review.