### PR TITLE
fix #151

### DIFF
--- a/applications/createxdmf/main.cpp
+++ b/applications/createxdmf/main.cpp
@@ -150,8 +150,7 @@ PetscErrorCode writeSingleXDMF(const std::string &directory,
     ierr = PetscViewerASCIIPrintf(viewer,
                                   "<!DOCTYPE Xdmf SYSTEM \"Xdmf.dtd\" [\n");
     CHKERRQ(ierr);
-    ierr = PetscViewerASCIIPrintf(
-        viewer, "\t<!ENTITY CaseDir \"%s\">\n", directory.c_str());
+    ierr = PetscViewerASCIIPrintf(viewer, "\t<!ENTITY CaseDir \"./\">\n");
     CHKERRQ(ierr);
 
     // always use 3D XDMF format, so both Visit and Paraview works


### PR DESCRIPTION
When we re-organized the location of output files recently, we
accidentally changed the value of CaseDir in XDMF files. The value
should be "./" (i.e., current location) because now XDMF files and all
HDF5 files are under the same directory.