### PR TITLE
[hot fix] fix number of iterations in AmgX solver for NVIDIA/AMGX#126

### DIFF
--- a/src/linsolver/linsolveramgx.cpp
+++ b/src/linsolver/linsolveramgx.cpp
@@ -120,7 +120,7 @@ PetscErrorCode LinSolverAmgX::getResidual(PetscReal &res)
     PetscInt iter;
 
     ierr = amgx.getIters(iter); CHKERRQ(ierr);
-    ierr = amgx.getResidual(iter - 1, res); CHKERRQ(ierr);
+    ierr = amgx.getResidual(iter, res); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
 }  // getResidual


### PR DESCRIPTION
Before AmgX v2.2, it reported number of iterations one higher than the actual value. So we manually minus one in the past. NVIDIA fixed the bug in v2.2. We also need to fix our end.

It affects when the actual number of iterations is `0` (For example, 2D cylinder flow Re=40 has zero-iteration Poisson solver once reaching steady state). Our current code then requests residual using iteration `-1`, which breaks the code.

See
* https://github.com/NVIDIA/AMGX/issues/126
* https://github.com/NVIDIA/AMGX/pull/131